### PR TITLE
DEVEXP-1073: Document Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 
 ### Prerequisites
 
-- [Node.js >= 20.18.1](https://nodejs.org/en/download)
+- [Node.js 20.x or 22.x (LTS)](https://nodejs.org/en/download)
 - A provisioned [Sinch Build account](https://dashboard.sinch.com/dashboard)
 - Claude Desktop (or any other MCP client). This README is focused on [Claude Desktop](https://claude.ai/download), but the MCP server can be used with any MCP client.
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "test:integration": "jest tests/integration/llms --runInBand"
   },
   "engines": {
-    "node": ">=20.18.1"
+    "node": ">=20.18.1 < 23"
   }
 }


### PR DESCRIPTION
Note: Node 24 is not supported yet because `better-sqlite3` does not ship prebuilt binaries for it.
If we remove this dependency when evolving the MCP server, this limitation can be waived