### PR TITLE
Centralize server env vars with T3 Env for typed configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ npm run build
 
 ### Step 2: Set up the MCP server configuration
 
-Copy the file `.template.env` and rename it `.env`. Then replace the placeholders with your own credentials and delete any key you don't need. The `.env` file should look like this ():
+Copy the file `.template.env` and rename it `.env`. Then replace the placeholders with your own credentials and delete any key you don't need. Environment variables are parsed and typed at server startup via [T3 Env](https://env.t3.gg/); missing credentials only cause errors when you invoke a tool that requires them. The `.env` file should look like this ():
 ```dotenv
 # Conversation / Numbers tools related environment variables
 PROJECT_ID=

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@ import type {Config} from 'jest';
 const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/tests/setup/env.mock.ts'],
   roots: ['<rootDir>/src', '<rootDir>/tests'],
   testMatch: ['**/tests/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.17.3",
         "@sinch/sdk-core": "1.4.1",
+        "@t3-oss/env-core": "0.13.11",
         "axios": "1.9.0",
         "dotenv": "16.5.0",
         "express": "5.1.0",
@@ -1375,6 +1376,32 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@t3-oss/env-core": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/@t3-oss/env-core/-/env-core-0.13.11.tgz",
+      "integrity": "sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "arktype": "^2.1.0",
+        "typescript": ">=5.0.0",
+        "valibot": "^1.0.0-beta.7 || ^1.0.0",
+        "zod": "^3.24.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "arktype": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -7056,7 +7083,7 @@
     },
     "node_modules/typescript": {
       "version": "5.8.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.17.3",
     "@sinch/sdk-core": "1.4.1",
+    "@t3-oss/env-core": "0.13.11",
     "axios": "1.9.0",
     "dotenv": "16.5.0",
     "express": "5.1.0",

--- a/src/__mocks__/env.ts
+++ b/src/__mocks__/env.ts
@@ -1,0 +1,25 @@
+export type MockServerEnv = {
+  PROJECT_ID?: string;
+  KEY_ID?: string;
+  KEY_SECRET?: string;
+  CONVERSATION_APP_ID?: string;
+  CONVERSATION_REGION?: 'us' | 'eu' | 'br';
+  DEFAULT_SMS_ORIGINATOR?: string;
+  GEOCODING_API_KEY?: string;
+  APPLICATION_KEY?: string;
+  APPLICATION_SECRET?: string;
+  CALLING_LINE_IDENTIFICATION?: string;
+  MAILGUN_DOMAIN?: string;
+  MAILGUN_API_KEY?: string;
+  MAILGUN_SENDER_ADDRESS?: string;
+};
+
+export const mockEnv: MockServerEnv = {};
+
+export const env = mockEnv;
+
+export function resetMockEnv(): void {
+  for (const key of Object.keys(mockEnv) as (keyof MockServerEnv)[]) {
+    delete mockEnv[key];
+  }
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,45 @@
+import { createEnv, type StandardSchemaV1 } from '@t3-oss/env-core';
+import { config } from 'dotenv';
+import { z } from 'zod';
+
+config();
+
+export const env = createEnv({
+  server: {
+    PROJECT_ID: z.string().optional(),
+    KEY_ID: z.string().optional(),
+    KEY_SECRET: z.string().optional(),
+    CONVERSATION_APP_ID: z.string().optional(),
+    CONVERSATION_REGION: z.enum(['us', 'eu', 'br']).optional(),
+    DEFAULT_SMS_ORIGINATOR: z.string().optional(),
+    GEOCODING_API_KEY: z.string().optional(),
+    APPLICATION_KEY: z.string().optional(),
+    APPLICATION_SECRET: z.string().optional(),
+    CALLING_LINE_IDENTIFICATION: z.string().optional(),
+    MAILGUN_DOMAIN: z.string().optional(),
+    MAILGUN_API_KEY: z.string().optional(),
+    MAILGUN_SENDER_ADDRESS: z.string().optional(),
+  },
+  runtimeEnvStrict: {
+    PROJECT_ID: process.env.PROJECT_ID,
+    KEY_ID: process.env.KEY_ID,
+    KEY_SECRET: process.env.KEY_SECRET,
+    CONVERSATION_APP_ID: process.env.CONVERSATION_APP_ID,
+    CONVERSATION_REGION: process.env.CONVERSATION_REGION,
+    DEFAULT_SMS_ORIGINATOR: process.env.DEFAULT_SMS_ORIGINATOR,
+    GEOCODING_API_KEY: process.env.GEOCODING_API_KEY,
+    APPLICATION_KEY: process.env.APPLICATION_KEY,
+    APPLICATION_SECRET: process.env.APPLICATION_SECRET,
+    CALLING_LINE_IDENTIFICATION: process.env.CALLING_LINE_IDENTIFICATION,
+    MAILGUN_DOMAIN: process.env.MAILGUN_DOMAIN,
+    MAILGUN_API_KEY: process.env.MAILGUN_API_KEY,
+    MAILGUN_SENDER_ADDRESS: process.env.MAILGUN_SENDER_ADDRESS,
+  },
+  emptyStringAsUndefined: true,
+  onValidationError: (issues: readonly StandardSchemaV1.Issue[]) => {
+    console.error('Invalid environment variables:', issues);
+    throw new Error('Invalid environment variables');
+  },
+});
+
+export type ServerEnv = typeof env;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import dotenv from 'dotenv';
+import './env';
 import {
   instantiateMcpServer,
   parseArgs,
   registerCapabilities,
 } from './server';
-dotenv.config();
 
 export const main = async () => {
   const transport = new StdioServerTransport();

--- a/src/tools/conversation/list-messaging-templates.ts
+++ b/src/tools/conversation/list-messaging-templates.ts
@@ -5,7 +5,7 @@ import { getConversationService, setTemplateRegion } from './utils/conversation-
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { SupportedConversationRegion } from '@sinch/sdk-client';
-import process from 'process';
+import { env } from '../../env';
 
 const TOOL_KEY: ConversationToolKey = 'listMessagingTemplates';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -80,12 +80,12 @@ interface WhatsAppTemplatesResponse {
 
 const fetchWhatsAppSpecificTemplates = async () => {
   const resp = await fetch(
-    `https://provisioning.api.sinch.com/v1/projects/${process.env.PROJECT_ID}/whatsapp/templates`,
+    `https://provisioning.api.sinch.com/v1/projects/${env.PROJECT_ID}/whatsapp/templates`,
     {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: 'Basic ' + Buffer.from(`${process.env.KEY_ID}:${process.env.KEY_SECRET}`).toString('base64')
+        Authorization: 'Basic ' + Buffer.from(`${env.KEY_ID}:${env.KEY_SECRET}`).toString('base64')
       }
     }
   );

--- a/src/tools/conversation/utils/conversation-service-helper.ts
+++ b/src/tools/conversation/utils/conversation-service-helper.ts
@@ -10,14 +10,14 @@ import {
   REGION_PATTERN,
 } from '@sinch/sdk-client';
 import { ConversationService } from '@sinch/conversation';
-import process from 'process';
+import { env } from '../../../env';
 import { PromptResponse } from '../../../types';
 import { formatUserAgent } from '../../../utils';
 
 export const getConversationService = (toolName: string): ConversationService | PromptResponse => {
-  const projectId = process.env.PROJECT_ID;
-  const keyId     = process.env.KEY_ID;
-  const keySecret = process.env.KEY_SECRET;
+  const projectId = env.PROJECT_ID;
+  const keyId     = env.KEY_ID;
+  const keySecret = env.KEY_SECRET;
 
   if (!projectId || !keyId || !keySecret) {
     return new PromptResponse(
@@ -67,7 +67,7 @@ export const getConversationService = (toolName: string): ConversationService | 
 
 export const getConversationAppId = (appId: string | undefined): string | PromptResponse => {
   if (!appId) {
-    appId = process.env.CONVERSATION_APP_ID;
+    appId = env.CONVERSATION_APP_ID;
     if (!appId) {
       return new PromptResponse('The "CONVERSATION_APP_ID" is not set in the environment variables and the "appId" property is not provided.');
     }
@@ -76,7 +76,7 @@ export const getConversationAppId = (appId: string | undefined): string | Prompt
 }
 
 export const setConversationRegion = (promptRegion: string | undefined, conversationService: ConversationService) => {
-  const region = promptRegion ?? process.env.CONVERSATION_REGION ?? ConversationRegion.UNITED_STATES;
+  const region = promptRegion ?? env.CONVERSATION_REGION ?? ConversationRegion.UNITED_STATES;
   conversationService.lazyConversationClient.sharedConfig.conversationRegion = region;
   const formattedRegion = region !== '' ? `${region}.` : '';
   conversationService.lazyConversationClient.apiFetchClient!.apiClientOptions.hostname
@@ -85,7 +85,7 @@ export const setConversationRegion = (promptRegion: string | undefined, conversa
 }
 
 export const setTemplateRegion = (promptRegion: string | undefined, conversationService: ConversationService) => {
-  const region = promptRegion ?? process.env.CONVERSATION_REGION ?? ConversationRegion.UNITED_STATES;
+  const region = promptRegion ?? env.CONVERSATION_REGION ?? ConversationRegion.UNITED_STATES;
   conversationService.lazyConversationTemplateClient.sharedConfig.conversationRegion = region;
   const formattedRegion = region !== '' ? `${region}.` : '';
   conversationService.lazyConversationTemplateClient.apiFetchClient!.apiClientOptions.hostname

--- a/src/tools/conversation/utils/geocoding.ts
+++ b/src/tools/conversation/utils/geocoding.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { env } from '../../../env';
 
 interface GeocodingAddress {
   latitude: number;
@@ -16,7 +17,7 @@ export const getLatitudeLongitudeFromAddress = async (address: string): Promise<
     const url = 'https://maps.googleapis.com/maps/api/geocode/json';
     const queryParams = {
       address,
-      key: process.env.GEOCODING_API_KEY
+      key: env.GEOCODING_API_KEY
     };
 
     const response = await axios.get(url, {

--- a/src/tools/conversation/utils/send-message-builder.ts
+++ b/src/tools/conversation/utils/send-message-builder.ts
@@ -1,4 +1,5 @@
 import { Conversation, ConversationService } from '@sinch/conversation';
+import { env } from '../../../env';
 
 export const buildMessageBase = async (
   conversationService: ConversationService,
@@ -30,7 +31,7 @@ export const buildMessageBase = async (
   addSMSFallback(appConfiguration, channel, recipient, channel_identities);
 
   if(!sender) {
-    sender = process.env.DEFAULT_SMS_ORIGINATOR;
+    sender = env.DEFAULT_SMS_ORIGINATOR;
   }
   if (sender) {
     messageBase.channel_properties = {

--- a/src/tools/email/send-email.ts
+++ b/src/tools/email/send-email.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { formatUserAgent, isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getMailgunCredentials } from './utils/mailgun-service-helper';
+import { env } from '../../env';
 import { EmailToolKey, getToolName, sha256, toolsConfig } from './utils/mailgun-tools-helper';
 
 const SendEmailSchema = {
@@ -50,7 +51,7 @@ export const sendEmailHandler = async ({
   const credentials = maybeCredentials;
 
   if (!sender) {
-    sender = process.env.MAILGUN_SENDER_ADDRESS;
+    sender = env.MAILGUN_SENDER_ADDRESS;
     if (!sender) {
       return new PromptResponse(JSON.stringify({
         success: false,

--- a/src/tools/email/utils/mailgun-service-helper.ts
+++ b/src/tools/email/utils/mailgun-service-helper.ts
@@ -1,4 +1,5 @@
 import { PromptResponse } from '../../../types';
+import { env } from '../../../env';
 
 export type MailgunCredentials = {
   domain: string;
@@ -10,8 +11,8 @@ export const getMailgunCredentials = (domain: string | undefined): MailgunCreden
 
   let credentials: MailgunCredentials | undefined = undefined;
 
-  const mailgunDomain = domain || process.env.MAILGUN_DOMAIN;
-  const apiKey = process.env.MAILGUN_API_KEY;
+  const mailgunDomain = domain || env.MAILGUN_DOMAIN;
+  const apiKey = env.MAILGUN_API_KEY;
 
   if (mailgunDomain && apiKey) {
     credentials = {
@@ -36,7 +37,7 @@ export const getMailgunCredentials = (domain: string | undefined): MailgunCreden
 };
 
 export const getMailgunApiKey = (): string | PromptResponse => {
-  const apiKey = process.env.MAILGUN_API_KEY;
+  const apiKey = env.MAILGUN_API_KEY;
 
   if (!apiKey) {
     return new PromptResponse(JSON.stringify({

--- a/src/tools/numbers/list-rented-numbers.ts
+++ b/src/tools/numbers/list-rented-numbers.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { PromptResponse, Tags } from '../../types';
 import { formatUserAgent, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
+import { env } from '../../env';
 import { Numbers } from '@sinch/numbers';
 
 const ListRentedNumbersSchema = {
@@ -35,9 +36,9 @@ export const registerListRentedNumbers = (server: McpServer, tags: Tags[]) => {
 export const listRentedNumbersHandler = async (
   { regionCode, type, searchPattern, patternPosition, capability, size }: ListRentedNumbers
 ) => {
-  const projectId = process.env.PROJECT_ID;
-  const keyId     = process.env.KEY_ID;
-  const keySecret = process.env.KEY_SECRET;
+  const projectId = env.PROJECT_ID;
+  const keyId     = env.KEY_ID;
+  const keySecret = env.KEY_SECRET;
 
   if (!projectId || !keyId || !keySecret) {
     return new PromptResponse(

--- a/src/tools/numbers/utils/numbers-service-helper.ts
+++ b/src/tools/numbers/utils/numbers-service-helper.ts
@@ -6,15 +6,16 @@ import {
   Oauth2TokenRequest,
 } from '@sinch/sdk-client';
 import { NumbersService } from '@sinch/numbers';
+import { env } from '../../../env';
 import { PromptResponse } from '../../../types';
 import { formatUserAgent } from '../../../utils';
 
 export function getNumbersService(
   toolName: string
 ): NumbersService | PromptResponse {
-  const projectId = process.env.PROJECT_ID;
-  const keyId     = process.env.KEY_ID;
-  const keySecret = process.env.KEY_SECRET;
+  const projectId = env.PROJECT_ID;
+  const keyId     = env.KEY_ID;
+  const keySecret = env.KEY_SECRET;
 
   if (!projectId || !keyId || !keySecret) {
     return new PromptResponse(JSON.stringify({

--- a/src/tools/verification/utils/number-lookup-service-helper.ts
+++ b/src/tools/verification/utils/number-lookup-service-helper.ts
@@ -6,15 +6,16 @@ import {
   Oauth2TokenRequest,
 } from '@sinch/sdk-client';
 import { PromptResponse } from '../../../types';
+import { env } from '../../../env';
 import { formatUserAgent } from '../../../utils';
 import { NumberLookupService } from '@sinch/number-lookup';
 
 export function getNumberLookupService(
   toolName: string
 ): NumberLookupService | PromptResponse {
-  const projectId = process.env.PROJECT_ID;
-  const keyId     = process.env.KEY_ID;
-  const keySecret = process.env.KEY_SECRET;
+  const projectId = env.PROJECT_ID;
+  const keyId     = env.KEY_ID;
+  const keySecret = env.KEY_SECRET;
 
   if (!projectId || !keyId || !keySecret) {
     return new PromptResponse(JSON.stringify({

--- a/src/tools/verification/utils/verification-service-helper.ts
+++ b/src/tools/verification/utils/verification-service-helper.ts
@@ -1,4 +1,5 @@
 import { PromptResponse } from '../../../types';
+import { env } from '../../../env';
 import {
   AdditionalHeadersRequest,
   ApiFetchClient,
@@ -12,8 +13,8 @@ import { formatUserAgent } from '../../../utils';
 
 export const getVerificationService = (toolName: string): VerificationService | PromptResponse => {
 
-  const applicationKey = process.env.APPLICATION_KEY;
-  const applicationSecret = process.env.APPLICATION_SECRET;
+  const applicationKey = env.APPLICATION_KEY;
+  const applicationSecret = env.APPLICATION_SECRET;
 
   if (!applicationKey && !applicationSecret) {
     return new PromptResponse(

--- a/src/tools/voice/conference.ts
+++ b/src/tools/voice/conference.ts
@@ -3,6 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Voice } from '@sinch/voice';
 import { z } from 'zod';
 import { getVoiceService } from './utils/voice-service-helper';
+import { env } from '../../env';
 import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools-helper';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
@@ -40,7 +41,7 @@ export const conferenceCalloutHandler = async ({
   }
   const voiceService = maybeService;
 
-  const cli = process.env.CALLING_LINE_IDENTIFICATION;
+  const cli = env.CALLING_LINE_IDENTIFICATION;
 
   if (!conferenceId) {
     conferenceId = crypto.randomUUID();

--- a/src/tools/voice/tts-callout.ts
+++ b/src/tools/voice/tts-callout.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Voice } from '@sinch/voice';
 import { z } from 'zod';
 import { getVoiceService } from './utils/voice-service-helper';
+import { env } from '../../env';
 import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools-helper';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
@@ -39,7 +40,7 @@ export const ttsCalloutHandler = async ({
   }
   const voiceService = maybeService;
 
-  const cli = process.env.CALLING_LINE_IDENTIFICATION;
+  const cli = env.CALLING_LINE_IDENTIFICATION;
 
   const request: Voice.TtsCalloutRequestData = {
     ttsCalloutRequestBody: {

--- a/src/tools/voice/utils/voice-service-helper.ts
+++ b/src/tools/voice/utils/voice-service-helper.ts
@@ -1,4 +1,5 @@
 import { PromptResponse } from '../../../types';
+import { env } from '../../../env';
 import {
   AdditionalHeadersRequest,
   ApiFetchClient,
@@ -14,8 +15,8 @@ import { formatUserAgent } from '../../../utils';
 
 export const getVoiceService = (toolName: string): VoiceService | PromptResponse => {
 
-  const applicationKey = process.env.APPLICATION_KEY;
-  const applicationSecret = process.env.APPLICATION_SECRET;
+  const applicationKey = env.APPLICATION_KEY;
+  const applicationSecret = env.APPLICATION_SECRET;
 
   if (!applicationKey && !applicationSecret) {
     return new PromptResponse(

--- a/tests/helpers/mock-env.ts
+++ b/tests/helpers/mock-env.ts
@@ -1,0 +1,1 @@
+export { mockEnv, resetMockEnv, type MockServerEnv } from '../../src/__mocks__/env';

--- a/tests/setup/env.mock.ts
+++ b/tests/setup/env.mock.ts
@@ -1,0 +1,1 @@
+jest.mock('../../src/env', () => jest.requireActual('../../src/__mocks__/env'));

--- a/tests/tools/conversation/utils/conversation-service-helper.test.ts
+++ b/tests/tools/conversation/utils/conversation-service-helper.test.ts
@@ -8,26 +8,21 @@ import {
 } from '../../../../src/tools/conversation/utils/conversation-service-helper';
 import { PromptResponse } from '../../../../src/types';
 import { formatUserAgent } from '../../../../src/utils';
+import { mockEnv, resetMockEnv } from '../../../helpers/mock-env';
 
 jest.mock('@sinch/sdk-core/package.json', () => ({
   version: '1.0.0',
 }), { virtual: true });
 
 describe('getConversationService / getConversationTemplateService', () => {
-  const OLD_ENV = process.env;
   const PROJECT_ID = 'test-project';
   const TOOL_NAME = 'dummy-tool';
 
   beforeEach(() => {
-    jest.resetModules();
-    process.env = { ...OLD_ENV };
-    process.env.PROJECT_ID = PROJECT_ID;
-    process.env.KEY_ID = 'test-key-id';
-    process.env.KEY_SECRET = 'test-secret';
-  });
-
-  afterAll(() => {
-    process.env = OLD_ENV;
+    resetMockEnv();
+    mockEnv.PROJECT_ID = PROJECT_ID;
+    mockEnv.KEY_ID = 'test-key-id';
+    mockEnv.KEY_SECRET = 'test-secret';
   });
 
   test('returns a configured ConversationService from getConversationService', async () => {
@@ -77,7 +72,7 @@ describe('getConversationService / getConversationTemplateService', () => {
   });
 
   test('returns PromptResponse when env vars are missing', () => {
-    delete process.env.PROJECT_ID;
+    mockEnv.PROJECT_ID = undefined;
     const result = getConversationService(TOOL_NAME);
     expect(result).toBeInstanceOf(PromptResponse);
     expect((result as PromptResponse).promptResponse).toStrictEqual({
@@ -93,19 +88,23 @@ describe('getConversationService / getConversationTemplateService', () => {
 });
 
 describe('getConversationAppId', () => {
+  beforeEach(() => {
+    resetMockEnv();
+  });
+
   test('returns appId when passed explicitly', () => {
     const result = getConversationAppId('explicit-id');
     expect(result).toBe('explicit-id');
   });
 
   test('returns appId from env when not passed', () => {
-    process.env.CONVERSATION_APP_ID = 'env-id';
+    mockEnv.CONVERSATION_APP_ID = 'env-id';
     const result = getConversationAppId(undefined);
     expect(result).toBe('env-id');
   });
 
   test('returns PromptResponse when no appId is provided or in env', () => {
-    delete process.env.CONVERSATION_APP_ID;
+    mockEnv.CONVERSATION_APP_ID = undefined;
     const result = getConversationAppId(undefined);
     expect(result).toBeInstanceOf(PromptResponse);
     expect((result as PromptResponse).promptResponse).toStrictEqual({

--- a/tests/tools/conversation/utils/geocoding.test.ts
+++ b/tests/tools/conversation/utils/geocoding.test.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getLatitudeLongitudeFromAddress } from '../../../../src/tools/conversation/utils/geocoding';
+import { mockEnv, resetMockEnv } from '../../../helpers/mock-env';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -22,7 +23,8 @@ const mockSuccessResponse = {
 };
 
 beforeEach(() => {
-  process.env.GEOCODING_API_KEY = 'test-api-key';
+  resetMockEnv();
+  mockEnv.GEOCODING_API_KEY = 'test-api-key';
   jest.clearAllMocks();
 });
 
@@ -87,7 +89,7 @@ test('includes GEOCODING_API_KEY in query params', async () => {
 });
 
 test('returns fallback when GEOCODING_API_KEY is not set', async () => {
-  delete process.env.GEOCODING_API_KEY;
+  mockEnv.GEOCODING_API_KEY = undefined;
   const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
   const mockError = new Error('API key missing');

--- a/tests/tools/conversation/utils/send-message-builder.test.ts
+++ b/tests/tools/conversation/utils/send-message-builder.test.ts
@@ -1,5 +1,6 @@
 import { buildMessageBase } from '../../../../src/tools/conversation/utils/send-message-builder';
 import { Conversation } from '@sinch/conversation';
+import { mockEnv, resetMockEnv } from '../../../helpers/mock-env';
 
 const mockGetApp = jest.fn();
 
@@ -18,7 +19,8 @@ const baseAppConfig = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  process.env.DEFAULT_SMS_ORIGINATOR = '+12014444333';
+  resetMockEnv();
+  mockEnv.DEFAULT_SMS_ORIGINATOR = '+12014444333';
 });
 
 test('buildMessageBase sets correct base structure and adds SMS fallback when needed', async () => {
@@ -63,7 +65,7 @@ test('No SMS fallback is added if already included', async () => {
 });
 
 test('Does not set channel_properties if sender is undefined and env var is missing', async () => {
-  delete process.env.DEFAULT_SMS_ORIGINATOR;
+  mockEnv.DEFAULT_SMS_ORIGINATOR = undefined;
   mockGetApp.mockResolvedValue(baseAppConfig);
 
   const result = await buildMessageBase(mockConversationService as any, 'my-app-id', '+1234567890', ['SMS']);

--- a/tests/tools/numbers/release-rented-number.test.ts
+++ b/tests/tools/numbers/release-rented-number.test.ts
@@ -1,6 +1,7 @@
 import { releaseRentedNumberHandler } from '../../../src/tools/numbers/release-rented-number';
 import { PromptResponse } from '../../../src/types';
 import * as numbersServiceHelper from '../../../src/tools/numbers/utils/numbers-service-helper';
+import { mockEnv, resetMockEnv } from '../../helpers/mock-env';
 
 jest.mock('@sinch/sdk-core/package.json', () => ({
   version: '1.0.0',
@@ -11,22 +12,16 @@ const mockNumbersService = {
 };
 
 describe('releaseRentedNumberHandler', () => {
-  const OLD_ENV = process.env;
-
   beforeEach(() => {
     jest.restoreAllMocks();
     jest
       .spyOn(numbersServiceHelper, 'getNumbersService')
       .mockReturnValue(mockNumbersService as never);
     jest.clearAllMocks();
-    process.env = { ...OLD_ENV };
-    process.env.PROJECT_ID = 'test-project';
-    process.env.KEY_ID = 'test-key-id';
-    process.env.KEY_SECRET = 'test-secret';
-  });
-
-  afterAll(() => {
-    process.env = OLD_ENV;
+    resetMockEnv();
+    mockEnv.PROJECT_ID = 'test-project';
+    mockEnv.KEY_ID = 'test-key-id';
+    mockEnv.KEY_SECRET = 'test-secret';
   });
 
   it('returns a prompt response with released number data', async () => {
@@ -69,8 +64,11 @@ describe('releaseRentedNumberHandler', () => {
 
   it('returns prompt response when credentials are missing', async () => {
     jest.restoreAllMocks();
+    resetMockEnv();
 
-    delete process.env.PROJECT_ID;
+    mockEnv.PROJECT_ID = undefined;
+    mockEnv.KEY_ID = undefined;
+    mockEnv.KEY_SECRET = undefined;
 
     const result = await releaseRentedNumberHandler({
       phoneNumber: '+12015555555',

--- a/tests/tools/numbers/utils/numbers-service-helper.test.ts
+++ b/tests/tools/numbers/utils/numbers-service-helper.test.ts
@@ -3,26 +3,21 @@ import { ApiFetchClient, NUMBERS_HOSTNAME } from '@sinch/sdk-client';
 import { NumbersService } from '@sinch/numbers';
 import { formatUserAgent } from '../../../../src/utils';
 import { PromptResponse } from '../../../../src/types';
+import { mockEnv, resetMockEnv } from '../../../helpers/mock-env';
 
 jest.mock('@sinch/sdk-core/package.json', () => ({
   version: '1.0.0',
 }), { virtual: true });
 
 describe('getNumbersService', () => {
-  const OLD_ENV = process.env;
   const PROJECT_ID = 'test-project';
   const TOOL_NAME = 'release-rented-number';
 
   beforeEach(() => {
-    jest.resetModules();
-    process.env = { ...OLD_ENV };
-    process.env.PROJECT_ID = PROJECT_ID;
-    process.env.KEY_ID = 'test-key-id';
-    process.env.KEY_SECRET = 'test-secret';
-  });
-
-  afterAll(() => {
-    process.env = OLD_ENV;
+    resetMockEnv();
+    mockEnv.PROJECT_ID = PROJECT_ID;
+    mockEnv.KEY_ID = 'test-key-id';
+    mockEnv.KEY_SECRET = 'test-secret';
   });
 
   it('returns a configured NumbersService with production hostname', async () => {
@@ -43,7 +38,7 @@ describe('getNumbersService', () => {
   });
 
   it('returns prompt response when credentials are missing', () => {
-    delete process.env.PROJECT_ID;
+    mockEnv.PROJECT_ID = undefined;
 
     const result = getNumbersService(TOOL_NAME);
 

--- a/tests/tools/verification/utils/verification-service-helper.test.ts
+++ b/tests/tools/verification/utils/verification-service-helper.test.ts
@@ -2,25 +2,20 @@ import { ApiFetchClient } from '@sinch/sdk-client';
 import { VerificationService } from '@sinch/verification';
 import { getVerificationService } from '../../../../src/tools/verification/utils/verification-service-helper';
 import { formatUserAgent } from '../../../../src/utils';
+import { mockEnv, resetMockEnv } from '../../../helpers/mock-env';
 
 jest.mock('@sinch/sdk-core/package.json', () => ({
   version: '1.0.0',
 }), { virtual: true });
 
 describe('getVerificationService', () => {
-  const OLD_ENV = process.env;
   const APPLICATION_KEY = 'test-application-key';
   const TOOL_NAME = 'dummy-tool';
 
   beforeEach(() => {
-    jest.resetModules();
-    process.env = { ...OLD_ENV };
-    process.env.APPLICATION_KEY = APPLICATION_KEY;
-    process.env.APPLICATION_SECRET = 'test-application-secret';
-  });
-
-  afterAll(() => {
-    process.env = OLD_ENV;
+    resetMockEnv();
+    mockEnv.APPLICATION_KEY = APPLICATION_KEY;
+    mockEnv.APPLICATION_SECRET = 'test-application-secret';
   });
 
   test('returns a configured SinchClient from getVerificationService', async () => {

--- a/tests/tools/voice/utils/voice-service-helper.test.ts
+++ b/tests/tools/voice/utils/voice-service-helper.test.ts
@@ -2,25 +2,20 @@ import { getVoiceService } from '../../../../src/tools/voice/utils/voice-service
 import { ApiFetchClient } from '@sinch/sdk-client';
 import { VoiceService } from '@sinch/voice';
 import { formatUserAgent } from '../../../../src/utils';
+import { mockEnv, resetMockEnv } from '../../../helpers/mock-env';
 
 jest.mock('@sinch/sdk-core/package.json', () => ({
   version: '1.0.0',
 }), { virtual: true });
 
 describe('getVoiceService', () => {
-  const OLD_ENV = process.env;
   const APPLICATION_KEY = 'test-application-key';
   const TOOL_NAME = 'dummy-tool';
 
   beforeEach(() => {
-    jest.resetModules();
-    process.env = { ...OLD_ENV };
-    process.env.APPLICATION_KEY = APPLICATION_KEY;
-    process.env.APPLICATION_SECRET = 'test-application-secret';
-  });
-
-  afterAll(() => {
-    process.env = OLD_ENV;
+    resetMockEnv();
+    mockEnv.APPLICATION_KEY = APPLICATION_KEY;
+    mockEnv.APPLICATION_SECRET = 'test-application-secret';
   });
 
   test('returns a configured VoiceService from getVoiceService', async () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "composite": false
   },
-  "include": ["src", "package.json"]
+  "include": ["src", "package.json"],
+  "exclude": ["src/__mocks__"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
     "target": "ES2022",
     "module": "CommonJS",
     "moduleResolution": "node",
+    "paths": {
+      "@t3-oss/env-core": ["./node_modules/@t3-oss/env-core/dist/index.d.ts"]
+    },
     "esModuleInterop": true,
     "skipLibCheck": true,
     "allowJs": true,


### PR DESCRIPTION
Replace scattered process.env reads with a single Zod schema so env vars are parsed and typed at startup while keeping optional credentials and per-tool runtime validation unchanged.