### PR TITLE
chore: DEVEXP-1423 use new register features to avoid deprecation

### DIFF
--- a/src/prompts/conversation/app-id.ts
+++ b/src/prompts/conversation/app-id.ts
@@ -8,10 +8,14 @@ export const registerAppId = (server: McpServer, tags: Tags[]) => {
     return;
   }
 
-  server.prompt(
+  server.registerPrompt(
     'conversation-app-id',
     {
-      appId: z.string().describe('The ID of the app to use for the Sinch conversation API')
+      argsSchema: {
+        appId: z
+          .string()
+          .describe('The ID of the app to use for the Sinch conversation API'),
+      },
     },
     ({ appId }) => ({
       messages: [
@@ -19,10 +23,10 @@ export const registerAppId = (server: McpServer, tags: Tags[]) => {
           role: 'user',
           content: {
             type: 'text',
-            text: `Please include the app ID ${appId} when the request will require to use a tool related to the Sinch Conversation API.`
-          }
-        }
-      ]
-    })
+            text: `Please include the app ID ${appId} when the request will require to use a tool related to the Sinch Conversation API.`,
+          },
+        },
+      ],
+    }),
   );
 };

--- a/src/tools/conversation/create-conversation-app.ts
+++ b/src/tools/conversation/create-conversation-app.ts
@@ -11,13 +11,13 @@ import { appendRegionHint } from './utils/region-hint';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { ConversationRegionOverride } from './prompt-schemas';
 
-const CreateConversationAppInput = {
+const CreateConversationAppSchema = {
   displayName: z.string()
     .describe('Display name for the Conversation API app.'),
   region: ConversationRegionOverride,
 };
 
-type CreateConversationAppInputSchema = z.infer<z.ZodObject<typeof CreateConversationAppInput>>;
+type CreateConversationApp = z.infer<z.ZodObject<typeof CreateConversationAppSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'createConversationApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -29,7 +29,7 @@ export const registerCreateConversationApp = (server: McpServer, tags: Tags[]) =
     TOOL_NAME,
     {
       description: 'Create a new Conversation API app in the project. No channels are configured at creation; use set-sms-channel-on-app, set-rcs-channel-on-app, or set-whatsapp-channel-on-app to configure channels later. Read the conversation-app-setup resource for the full flow.',
-      inputSchema: CreateConversationAppInput,
+      inputSchema: CreateConversationAppSchema,
     },
     createConversationAppHandler,
   );
@@ -38,7 +38,7 @@ export const registerCreateConversationApp = (server: McpServer, tags: Tags[]) =
 export const createConversationAppHandler = async ({
   displayName,
   region,
-}: CreateConversationAppInputSchema): Promise<IPromptResponse> => {
+}: CreateConversationApp): Promise<IPromptResponse> => {
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/conversation/create-conversation-app.ts
+++ b/src/tools/conversation/create-conversation-app.ts
@@ -11,19 +11,25 @@ import { appendRegionHint } from './utils/region-hint';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { ConversationRegionOverride } from './prompt-schemas';
 
+const CreateConversationAppInput = {
+  displayName: z.string()
+    .describe('Display name for the Conversation API app.'),
+  region: ConversationRegionOverride,
+};
+
+type CreateConversationAppInputSchema = z.infer<z.ZodObject<typeof CreateConversationAppInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'createConversationApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerCreateConversationApp = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Create a new Conversation API app in the project. No channels are configured at creation; use set-sms-channel-on-app, set-rcs-channel-on-app, or set-whatsapp-channel-on-app to configure channels later. Read the conversation-app-setup resource for the full flow.',
     {
-      displayName: z.string()
-        .describe('Display name for the Conversation API app.'),
-      region: ConversationRegionOverride,
+      description: 'Create a new Conversation API app in the project. No channels are configured at creation; use set-sms-channel-on-app, set-rcs-channel-on-app, or set-whatsapp-channel-on-app to configure channels later. Read the conversation-app-setup resource for the full flow.',
+      inputSchema: CreateConversationAppInput,
     },
     createConversationAppHandler,
   );
@@ -32,10 +38,7 @@ export const registerCreateConversationApp = (server: McpServer, tags: Tags[]) =
 export const createConversationAppHandler = async ({
   displayName,
   region,
-}: {
-  displayName: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: CreateConversationAppInputSchema): Promise<IPromptResponse> => {
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/conversation/list-all-apps.ts
+++ b/src/tools/conversation/list-all-apps.ts
@@ -12,9 +12,11 @@ const TOOL_NAME = getToolName(TOOL_KEY);
 export const registerListAllApps = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Get a list of all Conversation apps in the account. Apps are created and configured in the Sinch Dashboard or with the Conversation API. The App is the entity that holds the credentials related to the various channels',
+    {
+      description: 'Get a list of all Conversation apps in the account. Apps are created and configured in the Sinch Dashboard or with the Conversation API. The App is the entity that holds the credentials related to the various channels',
+    },
     listAllAppsHandler
   );
 };

--- a/src/tools/conversation/list-messaging-templates.ts
+++ b/src/tools/conversation/list-messaging-templates.ts
@@ -13,9 +13,11 @@ const TOOL_NAME = getToolName(TOOL_KEY);
 export const registerListAllTemplates = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Get a list of all messaging-related templates (omni-channel or channel specific) belonging to an account. Note that the Email templates are NOT included in this list - they can be found with another tool: list-email-templates. Do not try to use this tool to list Email templates, it will not work.',
+    {
+      description: 'Get a list of all messaging-related templates (omni-channel or channel specific) belonging to an account. Note that the Email templates are NOT included in this list - they can be found with another tool: list-email-templates. Do not try to use this tool to list Email templates, it will not work.',
+    },
     listAllTemplatesHandler
   );
 };

--- a/src/tools/conversation/resources/register-conversation-resources.ts
+++ b/src/tools/conversation/resources/register-conversation-resources.ts
@@ -19,7 +19,7 @@ const RESOURCE_TAGS: Tags[] = [
 export const registerConversationResources = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, RESOURCE_TAGS)) return;
 
-  server.resource(
+  server.registerResource(
     'conversation-app-setup',
     CONVERSATION_APP_SETUP_URI,
     {

--- a/src/tools/conversation/send-card-or-choice-message.ts
+++ b/src/tools/conversation/send-card-or-choice-message.ts
@@ -41,24 +41,30 @@ const choiceMessage = z.object({
   { message: 'Must provide exactly one type of choice: call, location, text, or URL' }
 ).describe('Choice message that can be a call, location, text, or URL. Exactly one must be provided. The "title" parameter must not be provided is case of text choice.');
 
+const SendCardOrChoiceMessageInput = {
+  recipient: Recipient,
+  choiceContent: z.array(choiceMessage).max(10).optional().describe('The list of choices to send to the user'),
+  text: z.string().describe('The text to be sent along the choice array'),
+  mediaUrl: z.string().optional().describe('The media URL to be sent along the choice array'),
+  channel: ConversationChannel,
+  appId: ConversationAppIdOverride,
+  sender: MessageSenderNumberOverride,
+  region: ConversationRegionOverride,
+};
+
+type SendCardOrChoiceMessageInputSchema = z.infer<z.ZodObject<typeof SendCardOrChoiceMessageInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'sendCardOrChoiceMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendCardOrChoiceMessage = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Send a choice message to the user. The choice message can contain up to 3 choices if not text or up to 10 message if text only. Each choice can be a call message (phone number + title to display next to it), a location message (latitude / longitude + title to display next to it), a text message or a URL message (the URL to click on + title to display next to it). The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
     {
-      recipient: Recipient,
-      choiceContent: z.array(choiceMessage).max(10).optional().describe('The list of choices to send to the user'),
-      text: z.string().describe('The text to be sent along the choice array'),
-      mediaUrl: z.string().optional().describe('The media URL to be sent along the choice array'),
-      channel: ConversationChannel,
-      appId: ConversationAppIdOverride,
-      sender: MessageSenderNumberOverride,
-      region: ConversationRegionOverride,
+      description: 'Send a choice message to the user. The choice message can contain up to 3 choices if not text or up to 10 message if text only. Each choice can be a call message (phone number + title to display next to it), a location message (latitude / longitude + title to display next to it), a text message or a URL message (the URL to click on + title to display next to it). The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      inputSchema: SendCardOrChoiceMessageInput,
     },
     sendCardOrChoiceMessageHandler
   );
@@ -73,16 +79,7 @@ export const sendCardOrChoiceMessageHandler = async ({
   appId,
   sender,
   region
-}: {
-  recipient: string;
-  channel: string[];
-  choiceContent?: z.infer<typeof choiceMessage>[];
-  text: string;
-  mediaUrl?: string;
-  appId?: string;
-  sender?: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: SendCardOrChoiceMessageInputSchema): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-card-or-choice-message.ts
+++ b/src/tools/conversation/send-card-or-choice-message.ts
@@ -41,7 +41,7 @@ const choiceMessage = z.object({
   { message: 'Must provide exactly one type of choice: call, location, text, or URL' }
 ).describe('Choice message that can be a call, location, text, or URL. Exactly one must be provided. The "title" parameter must not be provided is case of text choice.');
 
-const SendCardOrChoiceMessageInput = {
+const SendCardOrChoiceMessageSchema = {
   recipient: Recipient,
   choiceContent: z.array(choiceMessage).max(10).optional().describe('The list of choices to send to the user'),
   text: z.string().describe('The text to be sent along the choice array'),
@@ -52,7 +52,7 @@ const SendCardOrChoiceMessageInput = {
   region: ConversationRegionOverride,
 };
 
-type SendCardOrChoiceMessageInputSchema = z.infer<z.ZodObject<typeof SendCardOrChoiceMessageInput>>;
+type SendCardOrChoiceMessage = z.infer<z.ZodObject<typeof SendCardOrChoiceMessageSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'sendCardOrChoiceMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -64,7 +64,7 @@ export const registerSendCardOrChoiceMessage = (server: McpServer, tags: Tags[])
     TOOL_NAME,
     {
       description: 'Send a choice message to the user. The choice message can contain up to 3 choices if not text or up to 10 message if text only. Each choice can be a call message (phone number + title to display next to it), a location message (latitude / longitude + title to display next to it), a text message or a URL message (the URL to click on + title to display next to it). The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
-      inputSchema: SendCardOrChoiceMessageInput,
+      inputSchema: SendCardOrChoiceMessageSchema,
     },
     sendCardOrChoiceMessageHandler
   );
@@ -79,7 +79,7 @@ export const sendCardOrChoiceMessageHandler = async ({
   appId,
   sender,
   region
-}: SendCardOrChoiceMessageInputSchema): Promise<IPromptResponse> => {
+}: SendCardOrChoiceMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-location-message.ts
+++ b/src/tools/conversation/send-location-message.ts
@@ -6,7 +6,11 @@ import {
   getConversationService,
   setConversationRegion,
 } from './utils/conversation-service-helper';
-import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
+import {
+  ConversationToolKey,
+  getToolName,
+  toolsConfig,
+} from './utils/conversation-tools-helper';
 import {
   Recipient,
   ConversationAppIdOverride,
@@ -26,24 +30,35 @@ const location = z.object({
   address: z.string().optional(),
 });
 
+const LocationMessageInput = {
+  recipient: Recipient,
+  address: location.describe(
+    'It can either be the plain text address that will be converted into latitude /longitude or directly the latitude / longitude coordinates if the user wants to send a specific location.',
+  ),
+  channel: ConversationChannel,
+  appId: ConversationAppIdOverride,
+  sender: MessageSenderNumberOverride,
+  region: ConversationRegionOverride,
+};
+
+type LocationMessageInputSchema = z.infer<z.ZodObject<typeof LocationMessageInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'sendLocationMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
-export const registerSendLocationMessage = (server: McpServer, tags: Tags[]) => {
+export const registerSendLocationMessage = (
+  server: McpServer,
+  tags: Tags[],
+) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Send a location message from an address given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
     {
-      recipient: Recipient,
-      address: location.describe('It can either be the plain text address that will be converted into latitude /longitude or directly the latitude / longitude coordinates if the user wants to send a specific location.'),
-      channel: ConversationChannel,
-      appId: ConversationAppIdOverride,
-      sender: MessageSenderNumberOverride,
-      region: ConversationRegionOverride,
+      description:'Send a location message from an address given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      inputSchema: LocationMessageInput,
     },
-    sendLocationMessageHandler
+    sendLocationMessageHandler,
   );
 };
 
@@ -53,15 +68,8 @@ export const sendLocationMessageHandler = async ({
   address,
   appId,
   sender,
-  region
-}: {
-  recipient: string;
-  channel: string[];
-  address: { lat?: number; long?: number; title?: string; address?: string; };
-  appId?: string;
-  sender?: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+  region,
+}: LocationMessageInputSchema): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;
@@ -75,10 +83,13 @@ export const sendLocationMessageHandler = async ({
   const conversationService = maybeService;
   const usedRegion = setConversationRegion(region, conversationService);
 
-  let latitude = 0, longitude = 0;
+  let latitude = 0,
+    longitude = 0;
   let formattedAddress = 'Default tile';
   if (address.address) {
-    const geocodingAddress = await getLatitudeLongitudeFromAddress(address.address);
+    const geocodingAddress = await getLatitudeLongitudeFromAddress(
+      address.address,
+    );
     latitude = geocodingAddress.latitude;
     longitude = geocodingAddress.longitude;
     formattedAddress = geocodingAddress.formattedAddress;
@@ -87,32 +98,46 @@ export const sendLocationMessageHandler = async ({
     longitude = address.long;
     formattedAddress = address.title;
   }
-  const requestBase = await buildMessageBase(conversationService, conversationAppId, recipient, channel, sender);
-  const request: Conversation.SendLocationMessageRequestData<Conversation.IdentifiedBy> = {
-    sendMessageRequestBody: {
-      ...requestBase,
-      message: {
-        location_message: {
-          coordinates: {
-            longitude,
-            latitude
+  const requestBase = await buildMessageBase(
+    conversationService,
+    conversationAppId,
+    recipient,
+    channel,
+    sender,
+  );
+  const request: Conversation.SendLocationMessageRequestData<Conversation.IdentifiedBy> =
+    {
+      sendMessageRequestBody: {
+        ...requestBase,
+        message: {
+          location_message: {
+            coordinates: {
+              longitude,
+              latitude,
+            },
+            title: formattedAddress,
           },
-          title: formattedAddress
-        }
-      }
-    }
-  };
+        },
+      },
+    };
 
   try {
-    const response = await conversationService.messages.sendLocationMessage(request);
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      message_id: response.message_id
-    })).promptResponse;
+    const response =
+      await conversationService.messages.sendLocationMessage(request);
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        message_id: response.message_id,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error)) + `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error:
+          (error instanceof Error ? error.message : String(error)) +
+          `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`,
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/send-location-message.ts
+++ b/src/tools/conversation/send-location-message.ts
@@ -30,7 +30,7 @@ const location = z.object({
   address: z.string().optional(),
 });
 
-const LocationMessageInput = {
+const LocationMessageSchema = {
   recipient: Recipient,
   address: location.describe(
     'It can either be the plain text address that will be converted into latitude /longitude or directly the latitude / longitude coordinates if the user wants to send a specific location.',
@@ -41,7 +41,7 @@ const LocationMessageInput = {
   region: ConversationRegionOverride,
 };
 
-type LocationMessageInputSchema = z.infer<z.ZodObject<typeof LocationMessageInput>>;
+type LocationMessage = z.infer<z.ZodObject<typeof LocationMessageSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'sendLocationMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -55,8 +55,8 @@ export const registerSendLocationMessage = (
   server.registerTool(
     TOOL_NAME,
     {
-      description:'Send a location message from an address given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
-      inputSchema: LocationMessageInput,
+      description: 'Send a location message from an address given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      inputSchema: LocationMessageSchema,
     },
     sendLocationMessageHandler,
   );
@@ -69,7 +69,7 @@ export const sendLocationMessageHandler = async ({
   appId,
   sender,
   region,
-}: LocationMessageInputSchema): Promise<IPromptResponse> => {
+}: LocationMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-media-message.ts
+++ b/src/tools/conversation/send-media-message.ts
@@ -12,22 +12,28 @@ import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { buildMessageBase } from './utils/send-message-builder';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
+const SendMediaMessageInput = {
+  recipient: Recipient,
+  url: z.string().describe('The URL of the media that will be the content of the message.'),
+  channel: ConversationChannel,
+  appId: ConversationAppIdOverride,
+  sender: MessageSenderNumberOverride,
+  region: ConversationRegionOverride,
+};
+
+type SendMediaMessageInputSchema = z.infer<z.ZodObject<typeof SendMediaMessageInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'sendMediaMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendMediaMessage = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Send a media message from URL given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel. The media must be specified with its URL.',
     {
-      recipient: Recipient,
-      url: z.string().describe('The URL of the media that will be the content of the message.'),
-      channel: ConversationChannel,
-      appId: ConversationAppIdOverride,
-      sender: MessageSenderNumberOverride,
-      region: ConversationRegionOverride
+      description: 'Send a media message from URL given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel. The media must be specified with its URL.',
+      inputSchema: SendMediaMessageInput,
     },
     sendMediaMessageHandler
   );
@@ -40,14 +46,7 @@ export const sendMediaMessageHandler = async({
   appId,
   sender,
   region
-}: {
-  recipient: string;
-  channel: string[];
-  url: string;
-  appId?: string;
-  sender?: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: SendMediaMessageInputSchema): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-media-message.ts
+++ b/src/tools/conversation/send-media-message.ts
@@ -12,7 +12,7 @@ import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { buildMessageBase } from './utils/send-message-builder';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
-const SendMediaMessageInput = {
+const SendMediaMessageSchema = {
   recipient: Recipient,
   url: z.string().describe('The URL of the media that will be the content of the message.'),
   channel: ConversationChannel,
@@ -21,7 +21,7 @@ const SendMediaMessageInput = {
   region: ConversationRegionOverride,
 };
 
-type SendMediaMessageInputSchema = z.infer<z.ZodObject<typeof SendMediaMessageInput>>;
+type SendMediaMessage = z.infer<z.ZodObject<typeof SendMediaMessageSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'sendMediaMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -33,7 +33,7 @@ export const registerSendMediaMessage = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Send a media message from URL given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel. The media must be specified with its URL.',
-      inputSchema: SendMediaMessageInput,
+      inputSchema: SendMediaMessageSchema,
     },
     sendMediaMessageHandler
   );
@@ -46,7 +46,7 @@ export const sendMediaMessageHandler = async({
   appId,
   sender,
   region
-}: SendMediaMessageInputSchema): Promise<IPromptResponse> => {
+}: SendMediaMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-template-message.ts
+++ b/src/tools/conversation/send-template-message.ts
@@ -12,7 +12,7 @@ import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversat
 import { buildMessageBase } from './utils/send-message-builder';
 import { Recipient, ConversationAppIdOverride, ConversationChannel, ConversationRegionOverride, MessageSenderNumberOverride } from './prompt-schemas';
 
-const SendTemplateMessageInput = {
+const SendTemplateMessageSchema = {
   recipient: Recipient,
   templateId: z.string()
     .describe('The ID (ULID format) of the omni-template template to use for sending the message.'),
@@ -26,7 +26,7 @@ const SendTemplateMessageInput = {
   region: ConversationRegionOverride,
 };
 
-type SendTemplateMessageInputSchema = z.infer<z.ZodObject<typeof SendTemplateMessageInput>>;
+type SendTemplateMessage = z.infer<z.ZodObject<typeof SendTemplateMessageSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'sendTemplateMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -38,7 +38,7 @@ export const registerSendTemplateMessage = (server: McpServer, tags: Tags[]) => 
     TOOL_NAME,
     {
       description: 'Send a template message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
-      inputSchema: SendTemplateMessageInput,
+      inputSchema: SendTemplateMessageSchema,
     },
     sendTemplateMessageHandler
   );
@@ -53,7 +53,7 @@ export const sendTemplateMessageHandler = async ({
   appId,
   sender,
   region
-}: SendTemplateMessageInputSchema): Promise<IPromptResponse> => {
+}: SendTemplateMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-template-message.ts
+++ b/src/tools/conversation/send-template-message.ts
@@ -12,27 +12,33 @@ import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversat
 import { buildMessageBase } from './utils/send-message-builder';
 import { Recipient, ConversationAppIdOverride, ConversationChannel, ConversationRegionOverride, MessageSenderNumberOverride } from './prompt-schemas';
 
+const SendTemplateMessageInput = {
+  recipient: Recipient,
+  templateId: z.string()
+    .describe('The ID (ULID format) of the omni-template template to use for sending the message.'),
+  language: z.string().optional()
+    .describe('The language to use for the omni-template (BCP-47). If not set, the default language code will be used.'),
+  parameters: z.record(z.string(), z.string()).optional()
+    .describe('The parameters to use for the template. This is a key-value map where the key is the parameter name and the value is the parameter value. Look carefully in the prompt to find which parameters are expected by the template.'),
+  channel: ConversationChannel,
+  appId: ConversationAppIdOverride,
+  sender: MessageSenderNumberOverride,
+  region: ConversationRegionOverride,
+};
+
+type SendTemplateMessageInputSchema = z.infer<z.ZodObject<typeof SendTemplateMessageInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'sendTemplateMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendTemplateMessage = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Send a template message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
     {
-      recipient: Recipient,
-      templateId: z.string()
-        .describe('The ID (ULID format) of the omni-template template to use for sending the message.'),
-      language: z.string().optional()
-        .describe('The language to use for the omni-template (BCP-47). If not set, the default language code will be used.'),
-      parameters: z.record(z.string(), z.string()).optional()
-        .describe('The parameters to use for the template. This is a key-value map where the key is the parameter name and the value is the parameter value. Look carefully in the prompt to find which parameters are expected by the template.'),
-      channel: ConversationChannel,
-      appId: ConversationAppIdOverride,
-      sender: MessageSenderNumberOverride,
-      region: ConversationRegionOverride
+      description: 'Send a template message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      inputSchema: SendTemplateMessageInput,
     },
     sendTemplateMessageHandler
   );
@@ -47,16 +53,7 @@ export const sendTemplateMessageHandler = async ({
   appId,
   sender,
   region
-}: {
-  recipient: string;
-  channel: string[];
-  templateId: string;
-  language?: string;
-  parameters?: Record<string, string>;
-  appId?: string;
-  sender?: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: SendTemplateMessageInputSchema): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-text-message.ts
+++ b/src/tools/conversation/send-text-message.ts
@@ -19,7 +19,7 @@ import {
 } from './prompt-schemas';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
-const SendTextMessageInput = {
+const SendTextMessageSchema = {
   recipient: Recipient,
   message: TextMessage,
   channel: ConversationChannel,
@@ -28,7 +28,7 @@ const SendTextMessageInput = {
   region: ConversationRegionOverride,
 };
 
-type SendTextMessageInputSchema = z.infer<z.ZodObject<typeof SendTextMessageInput>>;
+type SendTextMessage = z.infer<z.ZodObject<typeof SendTextMessageSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'sendTextMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -40,7 +40,7 @@ export const registerSendTextMessage = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Send a text message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
-      inputSchema: SendTextMessageInput,
+      inputSchema: SendTextMessageSchema,
     },
     sendTextMessageHandler
   );
@@ -53,7 +53,7 @@ export const sendTextMessageHandler = async({
   appId,
   sender,
   region,
-}: SendTextMessageInputSchema): Promise<IPromptResponse> => {
+}: SendTextMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-text-message.ts
+++ b/src/tools/conversation/send-text-message.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Conversation } from '@sinch/conversation';
+import { z } from 'zod';
 import {
   getConversationAppId,
   setConversationRegion,
@@ -18,22 +19,28 @@ import {
 } from './prompt-schemas';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
+const SendTextMessageInput = {
+  recipient: Recipient,
+  message: TextMessage,
+  channel: ConversationChannel,
+  appId: ConversationAppIdOverride,
+  sender: MessageSenderNumberOverride,
+  region: ConversationRegionOverride,
+};
+
+type SendTextMessageInputSchema = z.infer<z.ZodObject<typeof SendTextMessageInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'sendTextMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendTextMessage = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Send a text message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
     {
-      recipient: Recipient,
-      message: TextMessage,
-      channel: ConversationChannel,
-      appId: ConversationAppIdOverride,
-      sender: MessageSenderNumberOverride,
-      region: ConversationRegionOverride,
+      description: 'Send a text message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      inputSchema: SendTextMessageInput,
     },
     sendTextMessageHandler
   );
@@ -46,14 +53,7 @@ export const sendTextMessageHandler = async({
   appId,
   sender,
   region,
-}: {
-  message: string;
-  channel: string[];
-  recipient: string;
-  appId?: string;
-  sender?: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: SendTextMessageInputSchema): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-whatsapp-template-message.ts
+++ b/src/tools/conversation/send-whatsapp-template-message.ts
@@ -17,27 +17,33 @@ import {
   ConversationRegionOverride,
 } from './prompt-schemas';
 
+const SendWhatsAppTemplateMessageInput = {
+  recipient: Recipient,
+  templateName: z.string()
+    .describe('The name of the template to use for sending the message on WhatsApp specifically.'),
+  templateLanguage: z.string()
+    .describe('The language to use for the WhatsApp template (BCP-47).'),
+  parameters: z.record(z.string(), z.string()).optional()
+    .describe('The parameters to use for the template. This is a key-value map where the key is the parameter name and the value is the parameter value. Look carefully in the prompt to find which parameters are expected by the template.'),
+  appId: ConversationAppIdOverride,
+  sender: MessageSenderNumberOverride,
+  region: ConversationRegionOverride,
+  metadata: z.string().optional().describe('Custom data to send along with the message (e.g. correlation IDs, appointment IDs, etc.)'),
+};
+
+type SendWhatsAppTemplateMessageInputSchema = z.infer<z.ZodObject<typeof SendWhatsAppTemplateMessageInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'sendWhatsAppTemplateMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendWhatsAppTemplateMessage = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Send a template message to a contact (phone number in E.164 format) on the WhatsApp channel.',
     {
-      recipient: Recipient,
-      templateName: z.string()
-        .describe('The name of the template to use for sending the message on WhatsApp specifically.'),
-      templateLanguage: z.string()
-        .describe('The language to use for the WhatsApp template (BCP-47).'),
-      parameters: z.record(z.string(), z.string()).optional()
-        .describe('The parameters to use for the template. This is a key-value map where the key is the parameter name and the value is the parameter value. Look carefully in the prompt to find which parameters are expected by the template.'),
-      appId: ConversationAppIdOverride,
-      sender: MessageSenderNumberOverride,
-      region: ConversationRegionOverride,
-      metadata: z.string().optional().describe('Custom data to send along with the message (e.g. correlation IDs, appointment IDs, etc.)')
+      description: 'Send a template message to a contact (phone number in E.164 format) on the WhatsApp channel.',
+      inputSchema: SendWhatsAppTemplateMessageInput,
     },
     sendTemplateMessageHandler
   );
@@ -52,16 +58,7 @@ export const sendTemplateMessageHandler = async ({
   sender,
   region,
   metadata,
-}: {
-  recipient: string;
-  templateName: string;
-  templateLanguage: string;
-  parameters?: Record<string, string>;
-  appId?: string;
-  sender?: string;
-  metadata?: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: SendWhatsAppTemplateMessageInputSchema): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/send-whatsapp-template-message.ts
+++ b/src/tools/conversation/send-whatsapp-template-message.ts
@@ -17,7 +17,7 @@ import {
   ConversationRegionOverride,
 } from './prompt-schemas';
 
-const SendWhatsAppTemplateMessageInput = {
+const SendWhatsAppTemplateMessageSchema = {
   recipient: Recipient,
   templateName: z.string()
     .describe('The name of the template to use for sending the message on WhatsApp specifically.'),
@@ -31,7 +31,7 @@ const SendWhatsAppTemplateMessageInput = {
   metadata: z.string().optional().describe('Custom data to send along with the message (e.g. correlation IDs, appointment IDs, etc.)'),
 };
 
-type SendWhatsAppTemplateMessageInputSchema = z.infer<z.ZodObject<typeof SendWhatsAppTemplateMessageInput>>;
+type SendWhatsAppTemplateMessage = z.infer<z.ZodObject<typeof SendWhatsAppTemplateMessageSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'sendWhatsAppTemplateMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -43,7 +43,7 @@ export const registerSendWhatsAppTemplateMessage = (server: McpServer, tags: Tag
     TOOL_NAME,
     {
       description: 'Send a template message to a contact (phone number in E.164 format) on the WhatsApp channel.',
-      inputSchema: SendWhatsAppTemplateMessageInput,
+      inputSchema: SendWhatsAppTemplateMessageSchema,
     },
     sendTemplateMessageHandler
   );
@@ -58,7 +58,7 @@ export const sendTemplateMessageHandler = async ({
   sender,
   region,
   metadata,
-}: SendWhatsAppTemplateMessageInputSchema): Promise<IPromptResponse> => {
+}: SendWhatsAppTemplateMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
     return maybeAppId.promptResponse;

--- a/src/tools/conversation/set-rcs-channel-on-app.ts
+++ b/src/tools/conversation/set-rcs-channel-on-app.ts
@@ -14,7 +14,7 @@ import {
   ConversationRegionOverride,
 } from './prompt-schemas';
 
-const SetRcsChannelOnAppInput = {
+const SetRcsChannelOnAppSchema = {
   appId: ConversationAppId,
   senderId: z.string()
     .describe('RCS sender ID.'),
@@ -23,7 +23,7 @@ const SetRcsChannelOnAppInput = {
   region: ConversationRegionOverride,
 };
 
-type SetRcsChannelOnAppInputSchema = z.infer<z.ZodObject<typeof SetRcsChannelOnAppInput>>;
+type SetRcsChannelOnApp = z.infer<z.ZodObject<typeof SetRcsChannelOnAppSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'setRcsChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -35,7 +35,7 @@ export const registerSetRcsChannelOnApp = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Set (create or replace) the RCS channel on a Conversation API app. Requires the RCS sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
-      inputSchema: SetRcsChannelOnAppInput,
+      inputSchema: SetRcsChannelOnAppSchema,
     },
     setRcsChannelOnAppHandler,
   );
@@ -46,7 +46,7 @@ export const setRcsChannelOnAppHandler = async ({
   senderId,
   bearerToken,
   region,
-}: SetRcsChannelOnAppInputSchema): Promise<IPromptResponse> => {
+}: SetRcsChannelOnApp): Promise<IPromptResponse> => {
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/conversation/set-rcs-channel-on-app.ts
+++ b/src/tools/conversation/set-rcs-channel-on-app.ts
@@ -14,22 +14,28 @@ import {
   ConversationRegionOverride,
 } from './prompt-schemas';
 
+const SetRcsChannelOnAppInput = {
+  appId: ConversationAppId,
+  senderId: z.string()
+    .describe('RCS sender ID.'),
+  bearerToken: z.string()
+    .describe('Bearer token for the RCS channel.'),
+  region: ConversationRegionOverride,
+};
+
+type SetRcsChannelOnAppInputSchema = z.infer<z.ZodObject<typeof SetRcsChannelOnAppInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'setRcsChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSetRcsChannelOnApp = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Set (create or replace) the RCS channel on a Conversation API app. Requires the RCS sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
     {
-      appId: ConversationAppId,
-      senderId: z.string()
-        .describe('RCS sender ID.'),
-      bearerToken: z.string()
-        .describe('Bearer token for the RCS channel.'),
-      region: ConversationRegionOverride,
+      description: 'Set (create or replace) the RCS channel on a Conversation API app. Requires the RCS sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
+      inputSchema: SetRcsChannelOnAppInput,
     },
     setRcsChannelOnAppHandler,
   );
@@ -40,12 +46,7 @@ export const setRcsChannelOnAppHandler = async ({
   senderId,
   bearerToken,
   region,
-}: {
-  appId: string;
-  senderId: string;
-  bearerToken: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: SetRcsChannelOnAppInputSchema): Promise<IPromptResponse> => {
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/conversation/set-sms-channel-on-app.ts
+++ b/src/tools/conversation/set-sms-channel-on-app.ts
@@ -14,22 +14,28 @@ import {
   ConversationRegionOverride,
 } from './prompt-schemas';
 
+const SetSmsChannelOnAppInput = {
+  appId: ConversationAppId,
+  servicePlanId: z.string()
+    .describe('Sinch SMS service plan ID.'),
+  apiToken: z.string()
+    .describe('Sinch API token for the SMS service plan.'),
+  region: ConversationRegionOverride,
+};
+
+type SetSmsChannelOnAppInputSchema = z.infer<z.ZodObject<typeof SetSmsChannelOnAppInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'setSmsChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSetSmsChannelOnApp = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Set (create or replace) the SMS channel on a Conversation API app. Requires the SMS service plan ID and API token. The app must be in the same region as the SMS service plan. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
     {
-      appId: ConversationAppId,
-      servicePlanId: z.string()
-        .describe('Sinch SMS service plan ID.'),
-      apiToken: z.string()
-        .describe('Sinch API token for the SMS service plan.'),
-      region: ConversationRegionOverride,
+      description: 'Set (create or replace) the SMS channel on a Conversation API app. Requires the SMS service plan ID and API token. The app must be in the same region as the SMS service plan. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
+      inputSchema: SetSmsChannelOnAppInput,
     },
     setSmsChannelOnAppHandler,
   );
@@ -40,12 +46,7 @@ export const setSmsChannelOnAppHandler = async ({
   servicePlanId,
   apiToken,
   region,
-}: {
-  appId: string;
-  servicePlanId: string;
-  apiToken: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: SetSmsChannelOnAppInputSchema): Promise<IPromptResponse> => {
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/conversation/set-sms-channel-on-app.ts
+++ b/src/tools/conversation/set-sms-channel-on-app.ts
@@ -14,7 +14,7 @@ import {
   ConversationRegionOverride,
 } from './prompt-schemas';
 
-const SetSmsChannelOnAppInput = {
+const SetSmsChannelOnAppSchema = {
   appId: ConversationAppId,
   servicePlanId: z.string()
     .describe('Sinch SMS service plan ID.'),
@@ -23,7 +23,7 @@ const SetSmsChannelOnAppInput = {
   region: ConversationRegionOverride,
 };
 
-type SetSmsChannelOnAppInputSchema = z.infer<z.ZodObject<typeof SetSmsChannelOnAppInput>>;
+type SetSmsChannelOnApp = z.infer<z.ZodObject<typeof SetSmsChannelOnAppSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'setSmsChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -35,7 +35,7 @@ export const registerSetSmsChannelOnApp = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Set (create or replace) the SMS channel on a Conversation API app. Requires the SMS service plan ID and API token. The app must be in the same region as the SMS service plan. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
-      inputSchema: SetSmsChannelOnAppInput,
+      inputSchema: SetSmsChannelOnAppSchema,
     },
     setSmsChannelOnAppHandler,
   );
@@ -46,7 +46,7 @@ export const setSmsChannelOnAppHandler = async ({
   servicePlanId,
   apiToken,
   region,
-}: SetSmsChannelOnAppInputSchema): Promise<IPromptResponse> => {
+}: SetSmsChannelOnApp): Promise<IPromptResponse> => {
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/conversation/set-whatsapp-channel-on-app.ts
+++ b/src/tools/conversation/set-whatsapp-channel-on-app.ts
@@ -14,22 +14,28 @@ import {
   ConversationRegionOverride,
 } from './prompt-schemas';
 
+const SetWhatsAppChannelOnAppInput = {
+  appId: ConversationAppId,
+  senderId: z.string()
+    .describe('WhatsApp sender ID.'),
+  bearerToken: z.string()
+    .describe('Bearer token for the WhatsApp channel.'),
+  region: ConversationRegionOverride,
+};
+
+type SetWhatsAppChannelOnAppInputSchema = z.infer<z.ZodObject<typeof SetWhatsAppChannelOnAppInput>>;
+
 const TOOL_KEY: ConversationToolKey = 'setWhatsAppChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSetWhatsAppChannelOnApp = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Set (create or replace) the WhatsApp channel on a Conversation API app. Requires the WhatsApp sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
     {
-      appId: ConversationAppId,
-      senderId: z.string()
-        .describe('WhatsApp sender ID.'),
-      bearerToken: z.string()
-        .describe('Bearer token for the WhatsApp channel.'),
-      region: ConversationRegionOverride,
+      description: 'Set (create or replace) the WhatsApp channel on a Conversation API app. Requires the WhatsApp sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
+      inputSchema: SetWhatsAppChannelOnAppInput,
     },
     setWhatsAppChannelOnAppHandler,
   );
@@ -40,12 +46,7 @@ export const setWhatsAppChannelOnAppHandler = async ({
   senderId,
   bearerToken,
   region,
-}: {
-  appId: string;
-  senderId: string;
-  bearerToken: string;
-  region?: string;
-}): Promise<IPromptResponse> => {
+}: SetWhatsAppChannelOnAppInputSchema): Promise<IPromptResponse> => {
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/conversation/set-whatsapp-channel-on-app.ts
+++ b/src/tools/conversation/set-whatsapp-channel-on-app.ts
@@ -14,7 +14,7 @@ import {
   ConversationRegionOverride,
 } from './prompt-schemas';
 
-const SetWhatsAppChannelOnAppInput = {
+const SetWhatsAppChannelOnAppSchema = {
   appId: ConversationAppId,
   senderId: z.string()
     .describe('WhatsApp sender ID.'),
@@ -23,7 +23,7 @@ const SetWhatsAppChannelOnAppInput = {
   region: ConversationRegionOverride,
 };
 
-type SetWhatsAppChannelOnAppInputSchema = z.infer<z.ZodObject<typeof SetWhatsAppChannelOnAppInput>>;
+type SetWhatsAppChannelOnApp = z.infer<z.ZodObject<typeof SetWhatsAppChannelOnAppSchema>>;
 
 const TOOL_KEY: ConversationToolKey = 'setWhatsAppChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -35,7 +35,7 @@ export const registerSetWhatsAppChannelOnApp = (server: McpServer, tags: Tags[])
     TOOL_NAME,
     {
       description: 'Set (create or replace) the WhatsApp channel on a Conversation API app. Requires the WhatsApp sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
-      inputSchema: SetWhatsAppChannelOnAppInput,
+      inputSchema: SetWhatsAppChannelOnAppSchema,
     },
     setWhatsAppChannelOnAppHandler,
   );
@@ -46,7 +46,7 @@ export const setWhatsAppChannelOnAppHandler = async ({
   senderId,
   bearerToken,
   region,
-}: SetWhatsAppChannelOnAppInputSchema): Promise<IPromptResponse> => {
+}: SetWhatsAppChannelOnApp): Promise<IPromptResponse> => {
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/email/analytics-metrics.ts
+++ b/src/tools/email/analytics-metrics.ts
@@ -75,10 +75,12 @@ const TOOL_NAME = getToolName(TOOL_KEY);
 export const registerAnalyticsMetrics = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Get email analytics metrics from Mailgun for an account. All parameters are optional. You can filter by domain, metrics type and specify a time range. By default, it will return all metrics for all your domains for the last 7 days.',
-    AnalyticsMetricsInput,
+    {
+      description: 'Get email analytics metrics from Mailgun for an account. All parameters are optional. You can filter by domain, metrics type and specify a time range. By default, it will return all metrics for all your domains for the last 7 days.',
+      inputSchema: AnalyticsMetricsInput,
+    },
     analyticsMetricsHandler
   );
 };

--- a/src/tools/email/analytics-metrics.ts
+++ b/src/tools/email/analytics-metrics.ts
@@ -60,14 +60,14 @@ const metricsTypes = [
 
 type MetricsType = (typeof metricsTypes)[number];
 
-const AnalyticsMetricsInput = {
+const AnalyticsMetricsSchema = {
   domain: z.string().optional().describe('(Optional) The Mailgun domain to fetch metrics for.'),
   metrics: z.array(z.enum(metricsTypes)).optional().describe('(Optional) The specific metrics to receive the stats for. If not provided, all metrics will be returned.'),
   beginSearchPeriod: z.string().optional().describe('(Optional) The beginning of the search time range in RFC-2822 format (e.g., Mon, 02 Jun 2025 00:00:00 +0100).'),
   endSearchPeriod: z.string().optional().describe('(Optional) The end of the search time range in RFC-2822 format (e.g., Mon, 09 Jun 2025 00:00:00 +0100).'),
 }
 
-type AnalyticsMetricsInputSchema = z.infer<z.ZodObject<typeof AnalyticsMetricsInput>>;
+type AnalyticsMetrics = z.infer<z.ZodObject<typeof AnalyticsMetricsSchema>>;
 
 const TOOL_KEY: EmailToolKey = 'analyticsMetrics';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -79,7 +79,7 @@ export const registerAnalyticsMetrics = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Get email analytics metrics from Mailgun for an account. All parameters are optional. You can filter by domain, metrics type and specify a time range. By default, it will return all metrics for all your domains for the last 7 days.',
-      inputSchema: AnalyticsMetricsInput,
+      inputSchema: AnalyticsMetricsSchema,
     },
     analyticsMetricsHandler
   );
@@ -90,7 +90,7 @@ export const analyticsMetricsHandler = async ({
   metrics,
   beginSearchPeriod,
   endSearchPeriod
-}: AnalyticsMetricsInputSchema): Promise<IPromptResponse> => {
+}: AnalyticsMetrics): Promise<IPromptResponse> => {
   const maybeApiKey = getMailgunApiKey();
   if (typeof maybeApiKey !== 'string') {
     return maybeApiKey.promptResponse;

--- a/src/tools/email/list-email-events.ts
+++ b/src/tools/email/list-email-events.ts
@@ -12,7 +12,7 @@ const eventTypes = [
 
 type EventType = (typeof eventTypes)[number];
 
-const ListEmailEventsInput = {
+const ListEmailEventsSchema = {
   domain: z.string().optional().describe('(Optional) The Mailgun domain to fetch events for.'),
   event: z.enum(eventTypes).optional().describe('(Optional) Filter by event type (e.g., delivered, opened, failed).'),
   limit: z.number().int().min(1).max(300).optional().describe('(Optional) Number of events to return (max: 300).'),
@@ -20,7 +20,7 @@ const ListEmailEventsInput = {
   endSearchPeriod: z.string().datetime().optional().describe('(Optional) The end of the search time range in ISO 8601 format (e.g., 2025-01-01T00:00:00Z).'),
 };
 
-type ListEmailEventsInputSchema = z.infer<z.ZodObject<typeof ListEmailEventsInput>>;
+type ListEmailEvents = z.infer<z.ZodObject<typeof ListEmailEventsSchema>>;
 
 const TOOL_KEY: EmailToolKey = 'listEmailEvents';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -32,7 +32,7 @@ export const registerListEmailEvents = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Get a list of email events from Mailgun for a specific domain. You can filter by event type and limit the number of results.',
-      inputSchema: ListEmailEventsInput,
+      inputSchema: ListEmailEventsSchema,
     },
     listEmailEventsHandler
   );
@@ -44,7 +44,7 @@ export const listEmailEventsHandler = async ({
   limit,
   beginSearchPeriod,
   endSearchPeriod
-}: ListEmailEventsInputSchema): Promise<IPromptResponse> => {
+}: ListEmailEvents): Promise<IPromptResponse> => {
   const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;

--- a/src/tools/email/list-email-events.ts
+++ b/src/tools/email/list-email-events.ts
@@ -28,10 +28,12 @@ const TOOL_NAME = getToolName(TOOL_KEY);
 export const registerListEmailEvents = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Get a list of email events from Mailgun for a specific domain. You can filter by event type and limit the number of results.',
-    ListEmailEventsInput,
+    {
+      description: 'Get a list of email events from Mailgun for a specific domain. You can filter by event type and limit the number of results.',
+      inputSchema: ListEmailEventsInput,
+    },
     listEmailEventsHandler
   );
 };

--- a/src/tools/email/list-email-templates.ts
+++ b/src/tools/email/list-email-templates.ts
@@ -5,11 +5,11 @@ import { getMailgunCredentials } from './utils/mailgun-service-helper';
 import { EmailToolKey, getToolName, sha256, toolsConfig } from './utils/mailgun-tools-helper';
 import { formatUserAgent, isPromptResponse, matchesAnyTag } from '../../utils';
 
-const ListEmailTemplatesInput = {
+const ListEmailTemplatesSchema = {
   domain: z.string().optional().describe('The domain to use for sending the email. It would override the domain provided in the environment variables.'),
 };
 
-type ListEmailTemplatesInputSchema = z.infer<z.ZodObject<typeof ListEmailTemplatesInput>>;
+type ListEmailTemplates = z.infer<z.ZodObject<typeof ListEmailTemplatesSchema>>;
 
 const TOOL_KEY: EmailToolKey = 'listEmailTemplates';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -21,7 +21,7 @@ export const registerListEmailTemplates = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Get a list of Email templates from Mailgun for a specific domain. Note that the Messaging templates (omni-channel or channel-specific such as WhatsApp) are NOT included in this list - they can be found with another tool: list-messaging-templates. Do not try to use this tool to list Messaging templates, it will not work.',
-      inputSchema: ListEmailTemplatesInput,
+      inputSchema: ListEmailTemplatesSchema,
     },
     listEmailTemplatesHandler
   );
@@ -29,7 +29,7 @@ export const registerListEmailTemplates = (server: McpServer, tags: Tags[]) => {
 
 export const listEmailTemplatesHandler = async ({
   domain
-}: ListEmailTemplatesInputSchema): Promise<IPromptResponse> => {
+}: ListEmailTemplates): Promise<IPromptResponse> => {
   const maybeCredentials = await getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;

--- a/src/tools/email/list-email-templates.ts
+++ b/src/tools/email/list-email-templates.ts
@@ -5,17 +5,23 @@ import { getMailgunCredentials } from './utils/mailgun-service-helper';
 import { EmailToolKey, getToolName, sha256, toolsConfig } from './utils/mailgun-tools-helper';
 import { formatUserAgent, isPromptResponse, matchesAnyTag } from '../../utils';
 
+const ListEmailTemplatesInput = {
+  domain: z.string().optional().describe('The domain to use for sending the email. It would override the domain provided in the environment variables.'),
+};
+
+type ListEmailTemplatesInputSchema = z.infer<z.ZodObject<typeof ListEmailTemplatesInput>>;
+
 const TOOL_KEY: EmailToolKey = 'listEmailTemplates';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListEmailTemplates = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Get a list of Email templates from Mailgun for a specific domain. Note that the Messaging templates (omni-channel or channel-specific such as WhatsApp) are NOT included in this list - they can be found with another tool: list-messaging-templates. Do not try to use this tool to list Messaging templates, it will not work.',
     {
-      domain: z.string().optional().describe('The domain to use for sending the email. It would override the domain provided in the environment variables.')
+      description: 'Get a list of Email templates from Mailgun for a specific domain. Note that the Messaging templates (omni-channel or channel-specific such as WhatsApp) are NOT included in this list - they can be found with another tool: list-messaging-templates. Do not try to use this tool to list Messaging templates, it will not work.',
+      inputSchema: ListEmailTemplatesInput,
     },
     listEmailTemplatesHandler
   );
@@ -23,9 +29,7 @@ export const registerListEmailTemplates = (server: McpServer, tags: Tags[]) => {
 
 export const listEmailTemplatesHandler = async ({
   domain
-}: {
-  domain?: string;
-}): Promise<IPromptResponse> => {
+}: ListEmailTemplatesInputSchema): Promise<IPromptResponse> => {
   const maybeCredentials = await getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;

--- a/src/tools/email/retrieve-email-info.ts
+++ b/src/tools/email/retrieve-email-info.ts
@@ -18,18 +18,24 @@ interface Event {
   };
 }
 
+const RetrieveEmailInfoInput = {
+  emailId: z.string().describe('The email ID.'),
+  domain: z.string().optional().describe('The domain to use for retrieving the email. If defined, it will override the domain provided in the environment variable "MAILGUN_DOMAIN".'),
+};
+
+type RetrieveEmailInfoInputSchema = z.infer<z.ZodObject<typeof RetrieveEmailInfoInput>>;
+
 const TOOL_KEY: EmailToolKey = 'retrieveEmailInfo';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerRetrieveEmailInfo = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Retrieve the content of an email and the events that happened thanks to its ID',
     {
-      emailId: z.string().describe('The email ID.'),
-      domain: z.string().optional().describe('The domain to use for retrieving the email. If defined, it will override the domain provided in the environment variable "MAILGUN_DOMAIN".')
+      description: 'Retrieve the content of an email and the events that happened thanks to its ID',
+      inputSchema: RetrieveEmailInfoInput,
     },
     retrieveEmailInfoHandler
   );
@@ -38,10 +44,7 @@ export const registerRetrieveEmailInfo = (server: McpServer, tags: Tags[]) => {
 export const retrieveEmailInfoHandler = async({
   emailId,
   domain
-}: {
-  emailId: string;
-  domain?: string;
-}): Promise<IPromptResponse> => {
+}: RetrieveEmailInfoInputSchema): Promise<IPromptResponse> => {
   const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;

--- a/src/tools/email/retrieve-email-info.ts
+++ b/src/tools/email/retrieve-email-info.ts
@@ -18,12 +18,12 @@ interface Event {
   };
 }
 
-const RetrieveEmailInfoInput = {
+const RetrieveEmailInfoSchema = {
   emailId: z.string().describe('The email ID.'),
   domain: z.string().optional().describe('The domain to use for retrieving the email. If defined, it will override the domain provided in the environment variable "MAILGUN_DOMAIN".'),
 };
 
-type RetrieveEmailInfoInputSchema = z.infer<z.ZodObject<typeof RetrieveEmailInfoInput>>;
+type RetrieveEmailInfo = z.infer<z.ZodObject<typeof RetrieveEmailInfoSchema>>;
 
 const TOOL_KEY: EmailToolKey = 'retrieveEmailInfo';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -35,7 +35,7 @@ export const registerRetrieveEmailInfo = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Retrieve the content of an email and the events that happened thanks to its ID',
-      inputSchema: RetrieveEmailInfoInput,
+      inputSchema: RetrieveEmailInfoSchema,
     },
     retrieveEmailInfoHandler
   );
@@ -44,7 +44,7 @@ export const registerRetrieveEmailInfo = (server: McpServer, tags: Tags[]) => {
 export const retrieveEmailInfoHandler = async({
   emailId,
   domain
-}: RetrieveEmailInfoInputSchema): Promise<IPromptResponse> => {
+}: RetrieveEmailInfo): Promise<IPromptResponse> => {
   const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;

--- a/src/tools/email/send-email.ts
+++ b/src/tools/email/send-email.ts
@@ -6,23 +6,29 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getMailgunCredentials } from './utils/mailgun-service-helper';
 import { EmailToolKey, getToolName, sha256, toolsConfig } from './utils/mailgun-tools-helper';
 
+const SendEmailInput = {
+  recipient: z.string().describe('The recipient of the email.'),
+  subject: z.string().describe('The subject of the email.'),
+  sender: z.string().optional().describe('The sender of the email.'),
+  body: z.string().optional().describe('The body of the email. Can be text or HTML'),
+  template: z.string().optional().describe('The name of a template to use to render the email body. If provided, the body will be ignored.'),
+  templateVariables: z.record(z.string()).optional().describe('Variables to use in the template.'),
+  domain: z.string().optional().describe('The domain to use for sending the email. It would override the domain provided in the environment variables.'),
+};
+
+type SendEmailInputSchema = z.infer<z.ZodObject<typeof SendEmailInput>>;
+
 const TOOL_KEY: EmailToolKey = 'sendEmail';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendEmail = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Send an email to a recipient with a subject and body.',
     {
-      recipient: z.string().describe('The recipient of the email.'),
-      subject: z.string().describe('The subject of the email.'),
-      sender: z.string().optional().describe('The sender of the email.'),
-      body: z.string().optional().describe('The body of the email. Can be text or HTML'),
-      template: z.string().optional().describe('The name of a template to use to render the email body. If provided, the body will be ignored.'),
-      templateVariables: z.record(z.string()).optional().describe('Variables to use in the template.'),
-      domain: z.string().optional().describe('The domain to use for sending the email. It would override the domain provided in the environment variables.')
+      description: 'Send an email to a recipient with a subject and body.',
+      inputSchema: SendEmailInput,
     },
     sendEmailHandler
   );
@@ -36,15 +42,7 @@ export const sendEmailHandler = async ({
   template,
   templateVariables,
   domain
-}: {
-  recipient: string;
-  subject: string;
-  sender?: string;
-  body?: string;
-  template?: string;
-  templateVariables?: Record<string, string>;
-  domain?: string;
-}): Promise<IPromptResponse> => {
+}: SendEmailInputSchema): Promise<IPromptResponse> => {
   const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;

--- a/src/tools/email/send-email.ts
+++ b/src/tools/email/send-email.ts
@@ -6,7 +6,7 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getMailgunCredentials } from './utils/mailgun-service-helper';
 import { EmailToolKey, getToolName, sha256, toolsConfig } from './utils/mailgun-tools-helper';
 
-const SendEmailInput = {
+const SendEmailSchema = {
   recipient: z.string().describe('The recipient of the email.'),
   subject: z.string().describe('The subject of the email.'),
   sender: z.string().optional().describe('The sender of the email.'),
@@ -16,7 +16,7 @@ const SendEmailInput = {
   domain: z.string().optional().describe('The domain to use for sending the email. It would override the domain provided in the environment variables.'),
 };
 
-type SendEmailInputSchema = z.infer<z.ZodObject<typeof SendEmailInput>>;
+type SendEmail = z.infer<z.ZodObject<typeof SendEmailSchema>>;
 
 const TOOL_KEY: EmailToolKey = 'sendEmail';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -28,7 +28,7 @@ export const registerSendEmail = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Send an email to a recipient with a subject and body.',
-      inputSchema: SendEmailInput,
+      inputSchema: SendEmailSchema,
     },
     sendEmailHandler
   );
@@ -42,7 +42,7 @@ export const sendEmailHandler = async ({
   template,
   templateVariables,
   domain
-}: SendEmailInputSchema): Promise<IPromptResponse> => {
+}: SendEmail): Promise<IPromptResponse> => {
   const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;

--- a/src/tools/numbers/list-available-regions.ts
+++ b/src/tools/numbers/list-available-regions.ts
@@ -5,11 +5,11 @@ import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
 import { getNumbersService } from './utils/numbers-service-helper';
 
-const ListAvailableRegionsInput = {
+const ListAvailableRegionsSchema = {
   types: z.array(z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE'])).optional().describe('Only return regions for which numbers are provided with the given types: MOBILE, LOCAL or TOLL_FREE.'),
 };
 
-type ListAvailableRegionsInputSchema = z.infer<z.ZodObject<typeof ListAvailableRegionsInput>>;
+type ListAvailableRegions = z.infer<z.ZodObject<typeof ListAvailableRegionsSchema>>;
 
 const TOOL_KEY: NumbersToolKey = 'listAvailableRegions';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -21,14 +21,14 @@ export const registerListAvailableRegions = (server: McpServer, tags: Tags[]) =>
     TOOL_NAME,
     {
       description: 'Lists all regions for numbers provided for the project ID.',
-      inputSchema: ListAvailableRegionsInput,
+      inputSchema: ListAvailableRegionsSchema,
     },
     listAvailableRegionsHandler
   );
 }
 
 export const listAvailableRegionsHandler = async (
-  { types }: ListAvailableRegionsInputSchema
+  { types }: ListAvailableRegions
 ) => {
 
   const maybeService = getNumbersService(TOOL_NAME);

--- a/src/tools/numbers/list-available-regions.ts
+++ b/src/tools/numbers/list-available-regions.ts
@@ -5,26 +5,30 @@ import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
 import { getNumbersService } from './utils/numbers-service-helper';
 
+const ListAvailableRegionsInput = {
+  types: z.array(z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE'])).optional().describe('Only return regions for which numbers are provided with the given types: MOBILE, LOCAL or TOLL_FREE.'),
+};
+
+type ListAvailableRegionsInputSchema = z.infer<z.ZodObject<typeof ListAvailableRegionsInput>>;
+
 const TOOL_KEY: NumbersToolKey = 'listAvailableRegions';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListAvailableRegions = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Lists all regions for numbers provided for the project ID.',
     {
-      types: z.array(z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE'])).optional().describe('Only return regions for which numbers are provided with the given types: MOBILE, LOCAL or TOLL_FREE.'),
+      description: 'Lists all regions for numbers provided for the project ID.',
+      inputSchema: ListAvailableRegionsInput,
     },
     listAvailableRegionsHandler
   );
 }
 
 export const listAvailableRegionsHandler = async (
-  { types }: {
-    types?: ('MOBILE' | 'LOCAL' | 'TOLL_FREE')[];
-  }
+  { types }: ListAvailableRegionsInputSchema
 ) => {
 
   const maybeService = getNumbersService(TOOL_NAME);

--- a/src/tools/numbers/list-rented-numbers.ts
+++ b/src/tools/numbers/list-rented-numbers.ts
@@ -5,7 +5,7 @@ import { formatUserAgent, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
 import { Numbers } from '@sinch/numbers';
 
-const ListRentedNumbersInput = {
+const ListRentedNumbersSchema = {
   regionCode: z.string().optional().describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
   type: z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']).optional().describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
   searchPattern: z.string().optional().describe('Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.'),
@@ -14,7 +14,7 @@ const ListRentedNumbersInput = {
   size: z.number().optional().describe('Maximum number of phone numbers to return.'),
 };
 
-type ListRentedNumbersInputSchema = z.infer<z.ZodObject<typeof ListRentedNumbersInput>>;
+type ListRentedNumbers = z.infer<z.ZodObject<typeof ListRentedNumbersSchema>>;
 
 const TOOL_KEY: NumbersToolKey = 'listRentedNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -26,14 +26,14 @@ export const registerListRentedNumbers = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Lists all active numbers for a project.',
-      inputSchema: ListRentedNumbersInput,
+      inputSchema: ListRentedNumbersSchema,
     },
     listRentedNumbersHandler
   );
 }
 
 export const listRentedNumbersHandler = async (
-  { regionCode, type, searchPattern, patternPosition, capability, size }: ListRentedNumbersInputSchema
+  { regionCode, type, searchPattern, patternPosition, capability, size }: ListRentedNumbers
 ) => {
   const projectId = process.env.PROJECT_ID;
   const keyId     = process.env.KEY_ID;

--- a/src/tools/numbers/list-rented-numbers.ts
+++ b/src/tools/numbers/list-rented-numbers.ts
@@ -5,36 +5,35 @@ import { formatUserAgent, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
 import { Numbers } from '@sinch/numbers';
 
+const ListRentedNumbersInput = {
+  regionCode: z.string().optional().describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
+  type: z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']).optional().describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
+  searchPattern: z.string().optional().describe('Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.'),
+  patternPosition: z.enum(['START', 'CONTAINS', 'END']).optional().describe('Position of the search pattern. Options include START, END or CONTAINS. If you want the search pattern to be at the beginning of the phone number, select START. If you want it at the end, select END. If you want it to be anywhere in the phone number, select CONTAINS.'),
+  capability: z.enum(['SMS', 'VOICE']).optional().describe('Number capabilities to filter by SMS and/or VOICE.'),
+  size: z.number().optional().describe('Maximum number of phone numbers to return.'),
+};
+
+type ListRentedNumbersInputSchema = z.infer<z.ZodObject<typeof ListRentedNumbersInput>>;
+
 const TOOL_KEY: NumbersToolKey = 'listRentedNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListRentedNumbers = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Lists all active numbers for a project.',
     {
-      regionCode: z.string().optional().describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
-      type: z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']).optional().describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
-      searchPattern: z.string().optional().describe('Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.'),
-      patternPosition: z.enum(['START', 'CONTAINS', 'END']).optional().describe('Position of the search pattern. Options include START, END or CONTAINS. If you want the search pattern to be at the beginning of the phone number, select START. If you want it at the end, select END. If you want it to be anywhere in the phone number, select CONTAINS.'),
-      capability: z.enum(['SMS', 'VOICE']).optional().describe('Number capabilities to filter by SMS and/or VOICE.'),
-      size: z.number().optional().describe('Maximum number of phone numbers to return.'),
+      description: 'Lists all active numbers for a project.',
+      inputSchema: ListRentedNumbersInput,
     },
     listRentedNumbersHandler
   );
 }
 
 export const listRentedNumbersHandler = async (
-  { regionCode, type, searchPattern, patternPosition, capability, size }: {
-    regionCode?: string;
-    type?: 'MOBILE' | 'LOCAL' | 'TOLL_FREE';
-    searchPattern?: string;
-    patternPosition?: 'START' | 'END' | 'CONTAINS';
-    capability?: 'SMS' | 'VOICE';
-    size?: number;
-  }
+  { regionCode, type, searchPattern, patternPosition, capability, size }: ListRentedNumbersInputSchema
 ) => {
   const projectId = process.env.PROJECT_ID;
   const keyId     = process.env.KEY_ID;

--- a/src/tools/numbers/release-rented-number.ts
+++ b/src/tools/numbers/release-rented-number.ts
@@ -5,19 +5,25 @@ import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
 import { getNumbersService } from './utils/numbers-service-helper';
 
+const ReleaseRentedNumberInput = {
+  phoneNumber: z
+    .string()
+    .describe('The phone number in E.164 format with leading `+`'),
+};
+
+type ReleaseRentedNumberInputSchema = z.infer<z.ZodObject<typeof ReleaseRentedNumberInput>>;
+
 const TOOL_KEY: NumbersToolKey = 'releaseRentedNumber';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerReleaseRentedNumber = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Releases a rented phone number from your project.',
     {
-      phoneNumber: z
-        .string()
-        .describe('The phone number in E.164 format with leading `+`'),
+      description: 'Releases a rented phone number from your project.',
+      inputSchema: ReleaseRentedNumberInput,
     },
     releaseRentedNumberHandler
   );
@@ -25,9 +31,7 @@ export const registerReleaseRentedNumber = (server: McpServer, tags: Tags[]) => 
 
 export const releaseRentedNumberHandler = async ({
   phoneNumber,
-}: {
-  phoneNumber: string;
-}) => {
+}: ReleaseRentedNumberInputSchema) => {
   const maybeService = getNumbersService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/numbers/release-rented-number.ts
+++ b/src/tools/numbers/release-rented-number.ts
@@ -5,13 +5,13 @@ import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
 import { getNumbersService } from './utils/numbers-service-helper';
 
-const ReleaseRentedNumberInput = {
+const ReleaseRentedNumberSchema = {
   phoneNumber: z
     .string()
     .describe('The phone number in E.164 format with leading `+`'),
 };
 
-type ReleaseRentedNumberInputSchema = z.infer<z.ZodObject<typeof ReleaseRentedNumberInput>>;
+type ReleaseRentedNumber = z.infer<z.ZodObject<typeof ReleaseRentedNumberSchema>>;
 
 const TOOL_KEY: NumbersToolKey = 'releaseRentedNumber';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -23,7 +23,7 @@ export const registerReleaseRentedNumber = (server: McpServer, tags: Tags[]) => 
     TOOL_NAME,
     {
       description: 'Releases a rented phone number from your project.',
-      inputSchema: ReleaseRentedNumberInput,
+      inputSchema: ReleaseRentedNumberSchema,
     },
     releaseRentedNumberHandler
   );
@@ -31,7 +31,7 @@ export const registerReleaseRentedNumber = (server: McpServer, tags: Tags[]) => 
 
 export const releaseRentedNumberHandler = async ({
   phoneNumber,
-}: ReleaseRentedNumberInputSchema) => {
+}: ReleaseRentedNumber) => {
   const maybeService = getNumbersService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/numbers/rent-numbers.ts
+++ b/src/tools/numbers/rent-numbers.ts
@@ -6,24 +6,30 @@ import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-
 import { getNumbersService } from './utils/numbers-service-helper';
 import { Numbers } from '@sinch/numbers';
 
+const RentNumbersInput = {
+  numbers: z.array(z.string()).describe('Array of phone numbers to rent. Each number should be in E.164 format with leading `+`'),
+};
+
+type RentNumbersInputSchema = z.infer<z.ZodObject<typeof RentNumbersInput>>;
+
 const TOOL_KEY: NumbersToolKey = 'rentNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerRentNumbers = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Activates a phone number that matches the search criteria provided in the request. Currently the rentAny operation works only for US LOCAL numbers',
     {
-      numbers: z.array(z.string()).describe('Array of phone numbers to rent. Each number should be in E.164 format with leading `+`'),
+      description: 'Activates a phone number that matches the search criteria provided in the request. Currently the rentAny operation works only for US LOCAL numbers',
+      inputSchema: RentNumbersInput,
     },
     rentNumbersHandler
   );
 }
 
 export const rentNumbersHandler = async (
-  { numbers }: { numbers: string[]; }
+  { numbers }: RentNumbersInputSchema
 ) => {
 
   const maybeService = getNumbersService(TOOL_NAME);

--- a/src/tools/numbers/rent-numbers.ts
+++ b/src/tools/numbers/rent-numbers.ts
@@ -6,11 +6,11 @@ import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-
 import { getNumbersService } from './utils/numbers-service-helper';
 import { Numbers } from '@sinch/numbers';
 
-const RentNumbersInput = {
+const RentNumbersSchema = {
   numbers: z.array(z.string()).describe('Array of phone numbers to rent. Each number should be in E.164 format with leading `+`'),
 };
 
-type RentNumbersInputSchema = z.infer<z.ZodObject<typeof RentNumbersInput>>;
+type RentNumbers = z.infer<z.ZodObject<typeof RentNumbersSchema>>;
 
 const TOOL_KEY: NumbersToolKey = 'rentNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -22,14 +22,14 @@ export const registerRentNumbers = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Activates a phone number that matches the search criteria provided in the request. Currently the rentAny operation works only for US LOCAL numbers',
-      inputSchema: RentNumbersInput,
+      inputSchema: RentNumbersSchema,
     },
     rentNumbersHandler
   );
 }
 
 export const rentNumbersHandler = async (
-  { numbers }: RentNumbersInputSchema
+  { numbers }: RentNumbers
 ) => {
 
   const maybeService = getNumbersService(TOOL_NAME);

--- a/src/tools/numbers/search-for-available-numbers.ts
+++ b/src/tools/numbers/search-for-available-numbers.ts
@@ -5,7 +5,7 @@ import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
 import { getNumbersService } from './utils/numbers-service-helper';
 
-const SearchAvailableNumbersInput = {
+const SearchAvailableNumbersSchema = {
   regionCode: z.string().describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
   type: z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']).describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
   searchPattern: z.string().optional().describe('Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.'),
@@ -14,7 +14,7 @@ const SearchAvailableNumbersInput = {
   size: z.number().optional().describe('Maximum number of phone numbers to return.'),
 };
 
-type SearchAvailableNumbersInputSchema = z.infer<z.ZodObject<typeof SearchAvailableNumbersInput>>;
+type SearchAvailableNumbers = z.infer<z.ZodObject<typeof SearchAvailableNumbersSchema>>;
 
 const TOOL_KEY: NumbersToolKey = 'searchForAvailableNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -26,14 +26,14 @@ export const registerSearchAvailableNumbers = (server: McpServer, tags: Tags[]) 
     TOOL_NAME,
     {
       description: 'Search for available phone numbers that are available for you to activate. You can filter by any property on the available number resource.',
-      inputSchema: SearchAvailableNumbersInput,
+      inputSchema: SearchAvailableNumbersSchema,
     },
     searchAvailableNumbersHandler
   );
 }
 
 export const searchAvailableNumbersHandler = async (
-  { regionCode, type, searchPattern, patternPosition, capabilities, size }: SearchAvailableNumbersInputSchema
+  { regionCode, type, searchPattern, patternPosition, capabilities, size }: SearchAvailableNumbers
 ) => {
 
   const maybeService = getNumbersService(TOOL_NAME);

--- a/src/tools/numbers/search-for-available-numbers.ts
+++ b/src/tools/numbers/search-for-available-numbers.ts
@@ -5,36 +5,35 @@ import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-helper';
 import { getNumbersService } from './utils/numbers-service-helper';
 
+const SearchAvailableNumbersInput = {
+  regionCode: z.string().describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
+  type: z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']).describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
+  searchPattern: z.string().optional().describe('Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.'),
+  patternPosition: z.enum(['START', 'CONTAINS', 'END']).optional().describe('Position of the search pattern. Options include START, END or CONTAINS. If you want the search pattern to be at the beginning of the phone number, select START. If you want it at the end, select END. If you want it to be anywhere in the phone number, select CONTAINS.'),
+  capabilities: z.array(z.enum(['SMS', 'VOICE'])).optional().describe('Number capabilities to filter by SMS and/or VOICE.'),
+  size: z.number().optional().describe('Maximum number of phone numbers to return.'),
+};
+
+type SearchAvailableNumbersInputSchema = z.infer<z.ZodObject<typeof SearchAvailableNumbersInput>>;
+
 const TOOL_KEY: NumbersToolKey = 'searchForAvailableNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSearchAvailableNumbers = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Search for available phone numbers that are available for you to activate. You can filter by any property on the available number resource.',
     {
-      regionCode: z.string().describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
-      type: z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']).describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
-      searchPattern: z.string().optional().describe('Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.'),
-      patternPosition: z.enum(['START', 'CONTAINS', 'END']).optional().describe('Position of the search pattern. Options include START, END or CONTAINS. If you want the search pattern to be at the beginning of the phone number, select START. If you want it at the end, select END. If you want it to be anywhere in the phone number, select CONTAINS.'),
-      capabilities: z.array(z.enum(['SMS', 'VOICE'])).optional().describe('Number capabilities to filter by SMS and/or VOICE.'),
-      size: z.number().optional().describe('Maximum number of phone numbers to return.'),
+      description: 'Search for available phone numbers that are available for you to activate. You can filter by any property on the available number resource.',
+      inputSchema: SearchAvailableNumbersInput,
     },
     searchAvailableNumbersHandler
   );
 }
 
 export const searchAvailableNumbersHandler = async (
-  { regionCode, type, searchPattern, patternPosition, capabilities, size }: {
-    regionCode: string;
-    type: 'MOBILE' | 'LOCAL' | 'TOLL_FREE';
-    searchPattern?: string;
-    patternPosition?: 'START' | 'END' | 'CONTAINS';
-    capabilities?: ('SMS' | 'VOICE')[];
-    size?: number;
-  }
+  { regionCode, type, searchPattern, patternPosition, capabilities, size }: SearchAvailableNumbersInputSchema
 ) => {
 
   const maybeService = getNumbersService(TOOL_NAME);

--- a/src/tools/verification/number-lookup.ts
+++ b/src/tools/verification/number-lookup.ts
@@ -5,24 +5,30 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getToolName, VerificationToolKey, verificationToolsConfig } from './utils/verification-tools-helper';
 import { getNumberLookupService } from './utils/number-lookup-service-helper';
 
+const NumberLookupInput = {
+  phoneNumber: z.string().describe('Phone number in E.164 format to look up'),
+};
+
+type NumberLookupInputSchema = z.infer<z.ZodObject<typeof NumberLookupInput>>;
+
 const TOOL_KEY: VerificationToolKey = 'numberLookup';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerNumberLookup = (server: McpServer, tags: Tags[]) => {
   if(!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'With quick and easy access to Number Lookup, you can enhance your communications and keep your database as clean as a whistle. Number Lookup checks against first-party numbering sources and provides real-time feedback. Test numbers to ensure your recipients are ready and waiting to receive your messages!',
     {
-      phoneNumber: z.string().describe('Phone number in E.164 format to look up'),
+      description: 'With quick and easy access to Number Lookup, you can enhance your communications and keep your database as clean as a whistle. Number Lookup checks against first-party numbering sources and provides real-time feedback. Test numbers to ensure your recipients are ready and waiting to receive your messages!',
+      inputSchema: NumberLookupInput,
     },
     numberLookupHandler
   );
 };
 
 export const numberLookupHandler = async (
-  { phoneNumber }: { phoneNumber: string }
+  { phoneNumber }: NumberLookupInputSchema
 ): Promise<IPromptResponse> => {
 
   const maybeService = getNumberLookupService(TOOL_NAME);

--- a/src/tools/verification/number-lookup.ts
+++ b/src/tools/verification/number-lookup.ts
@@ -5,11 +5,11 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getToolName, VerificationToolKey, verificationToolsConfig } from './utils/verification-tools-helper';
 import { getNumberLookupService } from './utils/number-lookup-service-helper';
 
-const NumberLookupInput = {
+const NumberLookupSchema = {
   phoneNumber: z.string().describe('Phone number in E.164 format to look up'),
 };
 
-type NumberLookupInputSchema = z.infer<z.ZodObject<typeof NumberLookupInput>>;
+type NumberLookup = z.infer<z.ZodObject<typeof NumberLookupSchema>>;
 
 const TOOL_KEY: VerificationToolKey = 'numberLookup';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -21,14 +21,14 @@ export const registerNumberLookup = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'With quick and easy access to Number Lookup, you can enhance your communications and keep your database as clean as a whistle. Number Lookup checks against first-party numbering sources and provides real-time feedback. Test numbers to ensure your recipients are ready and waiting to receive your messages!',
-      inputSchema: NumberLookupInput,
+      inputSchema: NumberLookupSchema,
     },
     numberLookupHandler
   );
 };
 
 export const numberLookupHandler = async (
-  { phoneNumber }: NumberLookupInputSchema
+  { phoneNumber }: NumberLookup
 ): Promise<IPromptResponse> => {
 
   const maybeService = getNumberLookupService(TOOL_NAME);

--- a/src/tools/verification/report-sms-verification.ts
+++ b/src/tools/verification/report-sms-verification.ts
@@ -5,12 +5,12 @@ import { getToolName, VerificationToolKey, verificationToolsConfig } from './uti
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
-const ReportSmsVerificationInput = {
+const ReportSmsVerificationSchema = {
   phoneNumber: z.string().describe('Phone number in E.164 format used to start the verification process'),
   oneTimePassword: z.string().describe('The code which was received by the user submitting the SMS verification.'),
 };
 
-type ReportSmsVerificationInputSchema = z.infer<z.ZodObject<typeof ReportSmsVerificationInput>>;
+type ReportSmsVerification = z.infer<z.ZodObject<typeof ReportSmsVerificationSchema>>;
 
 const TOOL_KEY: VerificationToolKey = 'reportSmsVerification';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -22,14 +22,14 @@ export const registerReportSmsVerification = (server: McpServer, tags: Tags[]) =
     TOOL_NAME,
     {
       description: 'Report the received verification code to verify it, using the phone number of the user',
-      inputSchema: ReportSmsVerificationInput,
+      inputSchema: ReportSmsVerificationSchema,
     },
     reportSmsVerificationHandler
   );
 };
 
 export const reportSmsVerificationHandler = async (
-  { phoneNumber, oneTimePassword }: ReportSmsVerificationInputSchema
+  { phoneNumber, oneTimePassword }: ReportSmsVerification
 ): Promise<IPromptResponse> => {
   try {
     const maybeService = getVerificationService(TOOL_NAME);

--- a/src/tools/verification/report-sms-verification.ts
+++ b/src/tools/verification/report-sms-verification.ts
@@ -5,25 +5,31 @@ import { getToolName, VerificationToolKey, verificationToolsConfig } from './uti
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
+const ReportSmsVerificationInput = {
+  phoneNumber: z.string().describe('Phone number in E.164 format used to start the verification process'),
+  oneTimePassword: z.string().describe('The code which was received by the user submitting the SMS verification.'),
+};
+
+type ReportSmsVerificationInputSchema = z.infer<z.ZodObject<typeof ReportSmsVerificationInput>>;
+
 const TOOL_KEY: VerificationToolKey = 'reportSmsVerification';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerReportSmsVerification = (server: McpServer, tags: Tags[]) => {
   if(!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Report the received verification code to verify it, using the phone number of the user',
     {
-      phoneNumber: z.string().describe('Phone number in E.164 format used to start the verification process'),
-      oneTimePassword: z.string().describe('The code which was received by the user submitting the SMS verification.')
+      description: 'Report the received verification code to verify it, using the phone number of the user',
+      inputSchema: ReportSmsVerificationInput,
     },
     reportSmsVerificationHandler
   );
 };
 
 export const reportSmsVerificationHandler = async (
-  { phoneNumber, oneTimePassword }: { phoneNumber: string; oneTimePassword: string; }
+  { phoneNumber, oneTimePassword }: ReportSmsVerificationInputSchema
 ): Promise<IPromptResponse> => {
   try {
     const maybeService = getVerificationService(TOOL_NAME);

--- a/src/tools/verification/start-sms-verification.ts
+++ b/src/tools/verification/start-sms-verification.ts
@@ -5,11 +5,11 @@ import { getToolName, VerificationToolKey, verificationToolsConfig } from './uti
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
-const StartSmsVerificationInput = {
+const StartSmsVerificationSchema = {
   phoneNumber: z.string().describe('Phone number in E.164 format to send the SMS to'),
 };
 
-type StartSmsVerificationInputSchema = z.infer<z.ZodObject<typeof StartSmsVerificationInput>>;
+type StartSmsVerification = z.infer<z.ZodObject<typeof StartSmsVerificationSchema>>;
 
 const TOOL_KEY: VerificationToolKey = 'startSmsVerification';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -21,14 +21,14 @@ export const registerStartVerificationWithSms = (server: McpServer, tags: Tags[]
     TOOL_NAME,
     {
       description: 'Start new phone number verification requests. If the request is successful, you should ask the user to enter the OTP they received on the phone number we are verifying.',
-      inputSchema: StartSmsVerificationInput,
+      inputSchema: StartSmsVerificationSchema,
     },
     startSmsVerificationHandler
   );
 };
 
 export const startSmsVerificationHandler = async (
-  { phoneNumber }: StartSmsVerificationInputSchema
+  { phoneNumber }: StartSmsVerification
 ): Promise<IPromptResponse> => {
   try {
     const maybeService = getVerificationService(TOOL_NAME);

--- a/src/tools/verification/start-sms-verification.ts
+++ b/src/tools/verification/start-sms-verification.ts
@@ -5,24 +5,30 @@ import { getToolName, VerificationToolKey, verificationToolsConfig } from './uti
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
+const StartSmsVerificationInput = {
+  phoneNumber: z.string().describe('Phone number in E.164 format to send the SMS to'),
+};
+
+type StartSmsVerificationInputSchema = z.infer<z.ZodObject<typeof StartSmsVerificationInput>>;
+
 const TOOL_KEY: VerificationToolKey = 'startSmsVerification';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerStartVerificationWithSms = (server: McpServer, tags: Tags[]) => {
   if(!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Start new phone number verification requests. If the request is successful, you should ask the user to enter the OTP they received on the phone number we are verifying.',
     {
-      phoneNumber: z.string().describe('Phone number in E.164 format to send the SMS to')
+      description: 'Start new phone number verification requests. If the request is successful, you should ask the user to enter the OTP they received on the phone number we are verifying.',
+      inputSchema: StartSmsVerificationInput,
     },
     startSmsVerificationHandler
   );
 };
 
 export const startSmsVerificationHandler = async (
-  { phoneNumber }: { phoneNumber: string }
+  { phoneNumber }: StartSmsVerificationInputSchema
 ): Promise<IPromptResponse> => {
   try {
     const maybeService = getVerificationService(TOOL_NAME);

--- a/src/tools/voice/close-conference.ts
+++ b/src/tools/voice/close-conference.ts
@@ -5,11 +5,11 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getVoiceService } from './utils/voice-service-helper';
 import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools-helper';
 
-const CloseConferenceInput = {
+const CloseConferenceSchema = {
   conferenceId: z.string().describe('The conference ID to close'),
 };
 
-type CloseConferenceInputSchema = z.infer<z.ZodObject<typeof CloseConferenceInput>>;
+type CloseConference = z.infer<z.ZodObject<typeof CloseConferenceSchema>>;
 
 const TOOL_KEY: VoiceToolKey = 'closeConference';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -21,14 +21,14 @@ export const registerCloseConference = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Close a conference callout',
-      inputSchema: CloseConferenceInput,
+      inputSchema: CloseConferenceSchema,
     },
     closeConferenceHandler
   );
 };
 
 export const closeConferenceHandler = async (
-  { conferenceId }: CloseConferenceInputSchema
+  { conferenceId }: CloseConference
 ): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {

--- a/src/tools/voice/close-conference.ts
+++ b/src/tools/voice/close-conference.ts
@@ -5,24 +5,30 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getVoiceService } from './utils/voice-service-helper';
 import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools-helper';
 
+const CloseConferenceInput = {
+  conferenceId: z.string().describe('The conference ID to close'),
+};
+
+type CloseConferenceInputSchema = z.infer<z.ZodObject<typeof CloseConferenceInput>>;
+
 const TOOL_KEY: VoiceToolKey = 'closeConference';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerCloseConference = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Close a conference callout',
     {
-      conferenceId: z.string().describe('The conference ID to close')
+      description: 'Close a conference callout',
+      inputSchema: CloseConferenceInput,
     },
     closeConferenceHandler
   );
 };
 
 export const closeConferenceHandler = async (
-  { conferenceId }: { conferenceId: string }
+  { conferenceId }: CloseConferenceInputSchema
 ): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {

--- a/src/tools/voice/conference.ts
+++ b/src/tools/voice/conference.ts
@@ -7,18 +7,24 @@ import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
+const ConferenceCalloutInput = {
+  phoneNumbers: z.array(z.string()).describe('The phone numbers to call and connect to the conference room'),
+  conferenceId: z.string().optional().describe('The conference room ID. If not provided, a new one will be generated.'),
+};
+
+type ConferenceCalloutInputSchema = z.infer<z.ZodObject<typeof ConferenceCalloutInput>>;
+
 const TOOL_KEY: VoiceToolKey = 'conferenceCallout';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerConferenceCallout = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Call a phone number and connects it to a conference room when answered',
     {
-      phoneNumbers: z.array(z.string()).describe('The phone numbers to call and connect to the conference room'),
-      conferenceId: z.string().optional().describe('The conference room ID. If not provided, a new one will be generated.'),
+      description: 'Call a phone number and connects it to a conference room when answered',
+      inputSchema: ConferenceCalloutInput,
     },
     conferenceCalloutHandler
   );
@@ -27,10 +33,7 @@ export const registerConferenceCallout = (server: McpServer, tags: Tags[]) => {
 export const conferenceCalloutHandler = async ({
   phoneNumbers,
   conferenceId
-}: {
-  phoneNumbers: string[];
-  conferenceId?: string;
-}): Promise<IPromptResponse> => {
+}: ConferenceCalloutInputSchema): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/voice/conference.ts
+++ b/src/tools/voice/conference.ts
@@ -7,12 +7,12 @@ import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
-const ConferenceCalloutInput = {
+const ConferenceCalloutSchema = {
   phoneNumbers: z.array(z.string()).describe('The phone numbers to call and connect to the conference room'),
   conferenceId: z.string().optional().describe('The conference room ID. If not provided, a new one will be generated.'),
 };
 
-type ConferenceCalloutInputSchema = z.infer<z.ZodObject<typeof ConferenceCalloutInput>>;
+type ConferenceCallout = z.infer<z.ZodObject<typeof ConferenceCalloutSchema>>;
 
 const TOOL_KEY: VoiceToolKey = 'conferenceCallout';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -24,7 +24,7 @@ export const registerConferenceCallout = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Call a phone number and connects it to a conference room when answered',
-      inputSchema: ConferenceCalloutInput,
+      inputSchema: ConferenceCalloutSchema,
     },
     conferenceCalloutHandler
   );
@@ -33,7 +33,7 @@ export const registerConferenceCallout = (server: McpServer, tags: Tags[]) => {
 export const conferenceCalloutHandler = async ({
   phoneNumbers,
   conferenceId
-}: ConferenceCalloutInputSchema): Promise<IPromptResponse> => {
+}: ConferenceCallout): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/voice/get-call-information.ts
+++ b/src/tools/voice/get-call-information.ts
@@ -5,11 +5,11 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getVoiceService } from './utils/voice-service-helper';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 
-const GetCallInformationInput = {
+const GetCallInformationSchema = {
   callId: z.string().describe('The call ID to get information about'),
 };
 
-type GetCallInformationInputSchema = z.infer<z.ZodObject<typeof GetCallInformationInput>>;
+type GetCallInformation = z.infer<z.ZodObject<typeof GetCallInformationSchema>>;
 
 const TOOL_KEY: VoiceToolKey = 'getCallInformation';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -21,13 +21,13 @@ export const registerGetCallInformation = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Get information about a call using its ID',
-      inputSchema: GetCallInformationInput,
+      inputSchema: GetCallInformationSchema,
     },
     getCallInformationHandler
   );
 };
 
-export const getCallInformationHandler = async ({ callId }: GetCallInformationInputSchema): Promise<IPromptResponse> => {
+export const getCallInformationHandler = async ({ callId }: GetCallInformation): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/voice/get-call-information.ts
+++ b/src/tools/voice/get-call-information.ts
@@ -5,23 +5,29 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { getVoiceService } from './utils/voice-service-helper';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 
+const GetCallInformationInput = {
+  callId: z.string().describe('The call ID to get information about'),
+};
+
+type GetCallInformationInputSchema = z.infer<z.ZodObject<typeof GetCallInformationInput>>;
+
 const TOOL_KEY: VoiceToolKey = 'getCallInformation';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerGetCallInformation = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Get information about a call using its ID',
     {
-      callId: z.string().describe('The call ID to get information about')
+      description: 'Get information about a call using its ID',
+      inputSchema: GetCallInformationInput,
     },
     getCallInformationHandler
   );
 };
 
-export const getCallInformationHandler = async ({ callId }: { callId: string }): Promise<IPromptResponse> => {
+export const getCallInformationHandler = async ({ callId }: GetCallInformationInputSchema): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/voice/manage-conference-participant.ts
+++ b/src/tools/voice/manage-conference-participant.ts
@@ -5,19 +5,25 @@ import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
+const ManageConferenceParticipantInput = {
+  conferenceId: z.string().describe('The conference ID used in the callout to create the conference'),
+  participantId: z.string().describe('The participant ID, which is the call ID from the conference callout'),
+  action: z.enum(['mute', 'unmute', 'onhold', 'resume']).describe('The action to perform on the participant'),
+};
+
+type ManageConferenceParticipantInputSchema = z.infer<z.ZodObject<typeof ManageConferenceParticipantInput>>;
+
 const TOOL_KEY: VoiceToolKey = 'manageConferenceParticipant';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerManageConferenceParticipant = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Manage a conference participant. The conference is identified by the conference Id used in the callout, and the participants by the callId associated to their phone number when the conference callout to their number was made',
     {
-      conferenceId: z.string().describe('The conference ID used in the callout to create the conference'),
-      participantId: z.string().describe('The participant ID, which is the call ID from the conference callout'),
-      action: z.enum(['mute', 'unmute', 'onhold', 'resume']).describe('The action to perform on the participant')
+      description: 'Manage a conference participant. The conference is identified by the conference Id used in the callout, and the participants by the callId associated to their phone number when the conference callout to their number was made',
+      inputSchema: ManageConferenceParticipantInput,
     },
     manageConferenceParticipantHandler);
 };
@@ -26,11 +32,7 @@ export const manageConferenceParticipantHandler = async ({
   conferenceId,
   participantId,
   action
-}: {
-  conferenceId: string;
-  participantId: string;
-  action: 'mute' | 'unmute' | 'onhold' | 'resume';
-}): Promise<IPromptResponse> => {
+}: ManageConferenceParticipantInputSchema): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/voice/manage-conference-participant.ts
+++ b/src/tools/voice/manage-conference-participant.ts
@@ -5,13 +5,13 @@ import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
-const ManageConferenceParticipantInput = {
+const ManageConferenceParticipantSchema = {
   conferenceId: z.string().describe('The conference ID used in the callout to create the conference'),
   participantId: z.string().describe('The participant ID, which is the call ID from the conference callout'),
   action: z.enum(['mute', 'unmute', 'onhold', 'resume']).describe('The action to perform on the participant'),
 };
 
-type ManageConferenceParticipantInputSchema = z.infer<z.ZodObject<typeof ManageConferenceParticipantInput>>;
+type ManageConferenceParticipant = z.infer<z.ZodObject<typeof ManageConferenceParticipantSchema>>;
 
 const TOOL_KEY: VoiceToolKey = 'manageConferenceParticipant';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -23,7 +23,7 @@ export const registerManageConferenceParticipant = (server: McpServer, tags: Tag
     TOOL_NAME,
     {
       description: 'Manage a conference participant. The conference is identified by the conference Id used in the callout, and the participants by the callId associated to their phone number when the conference callout to their number was made',
-      inputSchema: ManageConferenceParticipantInput,
+      inputSchema: ManageConferenceParticipantSchema,
     },
     manageConferenceParticipantHandler);
 };
@@ -32,7 +32,7 @@ export const manageConferenceParticipantHandler = async ({
   conferenceId,
   participantId,
   action
-}: ManageConferenceParticipantInputSchema): Promise<IPromptResponse> => {
+}: ManageConferenceParticipant): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/voice/tts-callout.ts
+++ b/src/tools/voice/tts-callout.ts
@@ -6,12 +6,12 @@ import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
-const TtsCalloutInput = {
+const TtsCalloutSchema = {
   phoneNumber: z.string().describe('The phone number to call'),
   message: z.string().describe('The message to read out loud'),
 };
 
-type TtsCalloutInputSchema = z.infer<z.ZodObject<typeof TtsCalloutInput>>;
+type TtsCallout = z.infer<z.ZodObject<typeof TtsCalloutSchema>>;
 
 const TOOL_KEY: VoiceToolKey = 'ttsCallout';
 const TOOL_NAME = getToolName(TOOL_KEY);
@@ -23,7 +23,7 @@ export const registerTtsCallout = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description: 'Make a callout with a Text-To-Speech prompt',
-      inputSchema: TtsCalloutInput,
+      inputSchema: TtsCalloutSchema,
     },
     ttsCalloutHandler
   );
@@ -32,7 +32,7 @@ export const registerTtsCallout = (server: McpServer, tags: Tags[]) => {
 export const ttsCalloutHandler = async ({
   phoneNumber,
   message
-}: TtsCalloutInputSchema): Promise<IPromptResponse> => {
+}: TtsCallout): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;

--- a/src/tools/voice/tts-callout.ts
+++ b/src/tools/voice/tts-callout.ts
@@ -6,18 +6,24 @@ import { getToolName, VoiceToolKey, voiceToolsConfig } from './utils/voice-tools
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
+const TtsCalloutInput = {
+  phoneNumber: z.string().describe('The phone number to call'),
+  message: z.string().describe('The message to read out loud'),
+};
+
+type TtsCalloutInputSchema = z.infer<z.ZodObject<typeof TtsCalloutInput>>;
+
 const TOOL_KEY: VoiceToolKey = 'ttsCallout';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerTtsCallout = (server: McpServer, tags: Tags[]) => {
   if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
 
-  server.tool(
+  server.registerTool(
     TOOL_NAME,
-    'Make a callout with a Text-To-Speech prompt',
     {
-      phoneNumber: z.string().describe('The phone number to call'),
-      message: z.string().describe('The message to read out loud')
+      description: 'Make a callout with a Text-To-Speech prompt',
+      inputSchema: TtsCalloutInput,
     },
     ttsCalloutHandler
   );
@@ -26,10 +32,7 @@ export const registerTtsCallout = (server: McpServer, tags: Tags[]) => {
 export const ttsCalloutHandler = async ({
   phoneNumber,
   message
-}: {
-  phoneNumber: string;
-  message: string;
-}): Promise<IPromptResponse> => {
+}: TtsCalloutInputSchema): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;


### PR DESCRIPTION
Migrated all tool, prompt, and resource registrations from the discontinued `server.tool()`, `server.prompt()`, and `server.resource()` APIs to their `registerTool()`, `registerPrompt()`, and `registerResource()` equivalents, aligning with the MCP TypeScript SDK forward-compatible path (the legacy methods are removed in v2.0.0).

Standardised naming conventions across all tools: input shape objects as `XyzInput`, inferred types as `XyzInputSchema`.