### PR TITLE
Chore: fix eslint prettier configuration

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true,
-  "bracketSpacing": true
+  "bracketSpacing": true,
+  "printWidth": 120
 }

--- a/README.md
+++ b/README.md
@@ -10,68 +10,67 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 
 ### Conversation Tools
 
-| Tool                                  | Description                                                                                                                                                                                                                         | Tags                       |
-|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
-| **send-text-message**                 | Send a plain text message to a recipient on a supported channel. <br> *Example prompt*: "Send a quick update to the phone number +33612345678 on SMS."                                                                              | conversation, notification |
-| **send-media-message**                | Send an image, video, or document via a media message. <br> *Example prompt*: "Send the product brochure PDF to the phone number +33612345678 on WhatsApp."                                                                         | conversation, notification |
-| **send-template-message**             | Send a message using a predefined template (omni-template only). <br> *Example prompt*: "Send the appointment reminder template in Spanish to this user on Messenger."                                                              | conversation, notification |
-| **send-whatsapp-template-message**    | Send a message using a predefined WhatsApp template. <br> *Example prompt*: "Send a message using the template "appointment-reminder" on WhatsApp."                                                                                 | conversation, notification |
-| **send-choice-message**               | Send a message that includes interactive choices (buttons or quick replies). <br> *Example prompt*: "Send a RCS survey about preferred ice cream flavor to +33612345678 with the following choices: Vanilla, Strawberry, Hazelnut". | conversation, notification |
-| **send-location-message**             | Send a location pin or coordinates to a user. <br> *Example prompt*: "Send a pin to the Guggenheim Museum location in Bilbao to the phone number +33612345678."                                                                     | conversation, notification |
-| **list-conversation-apps**            | List all configured Conversation apps in the Sinch account. <br> *Example prompt*: "What messaging apps do I have set up in my account?"                                                                                            | conversation, notification |
-| **create-conversation-app**           | Create a new Conversation API app (no channels required at creation). <br> *Example prompt*: "Create a Conversation app named My Support Bot in the EU region."                                                                       | conversation, configuration |
-| **set-sms-channel-on-app**            | Set (create or replace) the SMS channel on a Conversation app. <br> *Example prompt*: "Set SMS on app abc123 using service plan XYZ and API token …"                                                                                   | conversation, configuration |
-| **set-rcs-channel-on-app**            | Set (create or replace) the RCS channel on a Conversation app. <br> *Example prompt*: "Set RCS on app abc123 with sender ID … and bearer token …"                                                                                   | conversation, configuration |
-| **set-whatsapp-channel-on-app**       | Set (create or replace) the WhatsApp channel on a Conversation app. <br> *Example prompt*: "Set WhatsApp on app abc123 with sender ID … and bearer token …"                                                                         | conversation, configuration |
-| **list-messaging-templates**          | List all omni-channel and channel-specific message templates. <br> *Example prompt*: "Show me all message templates in my account."                                                                                                 | conversation, notification |
-| **list-webhooks**                     | List webhooks configured for a Conversation app. <br> *Example prompt*: "List all webhooks for my Conversation app."                                                                                                                | conversation, configuration |
-| **get-webhook**                       | Get a webhook by ID. <br> *Example prompt*: "Show me the details of webhook ID abc123."                                                                                                                                             | conversation, configuration |
-| **create-webhook**                    | Create a webhook that delivers Conversation API events to a target URL. <br> *Example prompt*: "Create a webhook for inbound messages at https://example.com/callback."                                                             | conversation, configuration |
-| **update-webhook**                    | Update a webhook target URL and/or triggers. <br> *Example prompt*: "Update webhook abc123 to also receive MESSAGE_DELIVERY events."                                                                                                | conversation, configuration |
-| **delete-webhook**                    | Delete a webhook by ID. <br> *Example prompt*: "Delete webhook abc123."                                                                                                                                                             | conversation, configuration |
-
+| Tool                               | Description                                                                                                                                                                                                                         | Tags                        |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| **send-text-message**              | Send a plain text message to a recipient on a supported channel. <br> _Example prompt_: "Send a quick update to the phone number +33612345678 on SMS."                                                                              | conversation, notification  |
+| **send-media-message**             | Send an image, video, or document via a media message. <br> _Example prompt_: "Send the product brochure PDF to the phone number +33612345678 on WhatsApp."                                                                         | conversation, notification  |
+| **send-template-message**          | Send a message using a predefined template (omni-template only). <br> _Example prompt_: "Send the appointment reminder template in Spanish to this user on Messenger."                                                              | conversation, notification  |
+| **send-whatsapp-template-message** | Send a message using a predefined WhatsApp template. <br> _Example prompt_: "Send a message using the template "appointment-reminder" on WhatsApp."                                                                                 | conversation, notification  |
+| **send-choice-message**            | Send a message that includes interactive choices (buttons or quick replies). <br> _Example prompt_: "Send a RCS survey about preferred ice cream flavor to +33612345678 with the following choices: Vanilla, Strawberry, Hazelnut". | conversation, notification  |
+| **send-location-message**          | Send a location pin or coordinates to a user. <br> _Example prompt_: "Send a pin to the Guggenheim Museum location in Bilbao to the phone number +33612345678."                                                                     | conversation, notification  |
+| **list-conversation-apps**         | List all configured Conversation apps in the Sinch account. <br> _Example prompt_: "What messaging apps do I have set up in my account?"                                                                                            | conversation, notification  |
+| **create-conversation-app**        | Create a new Conversation API app (no channels required at creation). <br> _Example prompt_: "Create a Conversation app named My Support Bot in the EU region."                                                                     | conversation, configuration |
+| **set-sms-channel-on-app**         | Set (create or replace) the SMS channel on a Conversation app. <br> _Example prompt_: "Set SMS on app abc123 using service plan XYZ and API token …"                                                                                | conversation, configuration |
+| **set-rcs-channel-on-app**         | Set (create or replace) the RCS channel on a Conversation app. <br> _Example prompt_: "Set RCS on app abc123 with sender ID … and bearer token …"                                                                                   | conversation, configuration |
+| **set-whatsapp-channel-on-app**    | Set (create or replace) the WhatsApp channel on a Conversation app. <br> _Example prompt_: "Set WhatsApp on app abc123 with sender ID … and bearer token …"                                                                         | conversation, configuration |
+| **list-messaging-templates**       | List all omni-channel and channel-specific message templates. <br> _Example prompt_: "Show me all message templates in my account."                                                                                                 | conversation, notification  |
+| **list-webhooks**                  | List webhooks configured for a Conversation app. <br> _Example prompt_: "List all webhooks for my Conversation app."                                                                                                                | conversation, configuration |
+| **get-webhook**                    | Get a webhook by ID. <br> _Example prompt_: "Show me the details of webhook ID abc123."                                                                                                                                             | conversation, configuration |
+| **create-webhook**                 | Create a webhook that delivers Conversation API events to a target URL. <br> _Example prompt_: "Create a webhook for inbound messages at https://example.com/callback."                                                             | conversation, configuration |
+| **update-webhook**                 | Update a webhook target URL and/or triggers. <br> _Example prompt_: "Update webhook abc123 to also receive MESSAGE_DELIVERY events."                                                                                                | conversation, configuration |
+| **delete-webhook**                 | Delete a webhook by ID. <br> _Example prompt_: "Delete webhook abc123."                                                                                                                                                             | conversation, configuration |
 
 ### Email tools (Mailgun)
 
 | Tool                     | Description                                                                                                                                                                                          | Tags                |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
-| **send-email**           | Send an email using a predefined HTML template or raw HTML/text content. <br> *Example prompt*: "Send a welcome email to [john@example.com](mailto:john@example.com) using our onboarding template." | email, notification |
-| **list-email-templates** | List all email templates available for a specific domain. <br> *Example prompt*: "What email templates do I have available?"                                                                         | email, notification |
-| **retrieve-email-info**  | Retrieve metadata, content and delivery status for a specific email message. <br> *Example prompt*: "Can you get the delivery status of the email with ID <email-id>?"                               | email, notification |
-| **list-email-events**    | Retrieve and group recent email delivery events, such as bounces, opens, or clicks. <br> *Example prompt*: "Show me all recent email activity for my account."                                       | email               |
-| **analytics-metrics**    | Retrieve email analytics metrics, such as open rates or click-through rates. <br> *Example prompt*: "What are the open rates during the last week?"                                                  | email               |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| **send-email**           | Send an email using a predefined HTML template or raw HTML/text content. <br> _Example prompt_: "Send a welcome email to [john@example.com](mailto:john@example.com) using our onboarding template." | email, notification |
+| **list-email-templates** | List all email templates available for a specific domain. <br> _Example prompt_: "What email templates do I have available?"                                                                         | email, notification |
+| **retrieve-email-info**  | Retrieve metadata, content and delivery status for a specific email message. <br> _Example prompt_: "Can you get the delivery status of the email with ID <email-id>?"                               | email, notification |
+| **list-email-events**    | Retrieve and group recent email delivery events, such as bounces, opens, or clicks. <br> _Example prompt_: "Show me all recent email activity for my account."                                       | email               |
+| **analytics-metrics**    | Retrieve email analytics metrics, such as open rates or click-through rates. <br> _Example prompt_: "What are the open rates during the last week?"                                                  | email               |
 
 ### Verification Tools
 
-| Tool                              | Description                                                                                                                                             | Tags                       |
-|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
-| **number-lookup**                 | Lookup a phone number for its status and capabilities. <br> *Example prompt*: "Lookup for the following phone number capabilities: +33501020304."       | verification               |
-| **start-sms-verification**        | Initiate an SMS verification by sending an OTP to a user's phone number. <br> *Example prompt*: "Start phone verification for the number +33612345678." | verification               |
-| **report-sms-verification**       | Submit a one-time password (OTP) to complete SMS verification. <br> *Example prompt*: "Verify the phone number with this code: 1234."                   | verification               |
+| Tool                        | Description                                                                                                                                             | Tags         |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| **number-lookup**           | Lookup a phone number for its status and capabilities. <br> _Example prompt_: "Lookup for the following phone number capabilities: +33501020304."       | verification |
+| **start-sms-verification**  | Initiate an SMS verification by sending an OTP to a user's phone number. <br> _Example prompt_: "Start phone verification for the number +33612345678." | verification |
+| **report-sms-verification** | Submit a one-time password (OTP) to complete SMS verification. <br> _Example prompt_: "Verify the phone number with this code: 1234."                   | verification |
 
 ### Voice Tools
 
-| Tool                              | Description                                                                                                                                                                                              | Tags                       |
-|-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
-| **tts-callout**                   | Place a voice call and read aloud a message using Text-to-Speech. <br> *Example prompt*: "Call the phone number +33612345678 and say: 'Your appointment is tomorrow at 10 AM.'"                          | voice, notification        |
-| **conference-callout**            | Start a voice call to one or more participants and connect them to a shared conference. <br> *Example prompt*: "Call John (+33612345678) and Lisa (+34987654321) and connect them to a conference room." | voice                      |
-| **manage-conference-participant** | Mute, unmute, hold, or resume an individual participant in a conference call. <br> *Example prompt*: "Mute the caller with ID xyz789 in the conference."                                                 | voice                      |
-| **close-conference**              | End a conference call by disconnecting all the participants using the ID of the conference. <br> *Example prompt*: "End the current conference call with ID abc123."                                     | voice                      |
+| Tool                              | Description                                                                                                                                                                                              | Tags                |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| **tts-callout**                   | Place a voice call and read aloud a message using Text-to-Speech. <br> _Example prompt_: "Call the phone number +33612345678 and say: 'Your appointment is tomorrow at 10 AM.'"                          | voice, notification |
+| **conference-callout**            | Start a voice call to one or more participants and connect them to a shared conference. <br> _Example prompt_: "Call John (+33612345678) and Lisa (+34987654321) and connect them to a conference room." | voice               |
+| **manage-conference-participant** | Mute, unmute, hold, or resume an individual participant in a conference call. <br> _Example prompt_: "Mute the caller with ID xyz789 in the conference."                                                 | voice               |
+| **close-conference**              | End a conference call by disconnecting all the participants using the ID of the conference. <br> _Example prompt_: "End the current conference call with ID abc123."                                     | voice               |
 
 ### Numbers Tools
 
-| Tool                              | Description                                                                                                                                                                                                    | Tags    |
-|-----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| **list-available-regions**        | List all regions where phone numbers are available for the project. Can filter by number type (MOBILE, LOCAL, TOLL_FREE). <br> *Example prompt*: "Which regions have toll-free numbers available?"              | numbers |
-| **list-rented-numbers**           | List all active (rented) phone numbers for the project. Can filter by region, type, pattern, and capability. <br> *Example prompt*: "Show me all my active phone numbers in the US."                           | numbers |
-| **search-for-available-numbers**  | Search for phone numbers available to rent, with filters for region, type, pattern, and capabilities. <br> *Example prompt*: "Find available local numbers in the US that support SMS."                         | numbers |
-| **rent-sinch-virtual-numbers**    | Rent (activate) one or more phone numbers by providing them in E.164 format. <br> *Example prompt*: "Rent the phone number +12025551234."                                                                      | numbers |
+| Tool                             | Description                                                                                                                                                                                        | Tags    |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| **list-available-regions**       | List all regions where phone numbers are available for the project. Can filter by number type (MOBILE, LOCAL, TOLL_FREE). <br> _Example prompt_: "Which regions have toll-free numbers available?" | numbers |
+| **list-rented-numbers**          | List all active (rented) phone numbers for the project. Can filter by region, type, pattern, and capability. <br> _Example prompt_: "Show me all my active phone numbers in the US."               | numbers |
+| **search-for-available-numbers** | Search for phone numbers available to rent, with filters for region, type, pattern, and capabilities. <br> _Example prompt_: "Find available local numbers in the US that support SMS."            | numbers |
+| **rent-sinch-virtual-numbers**   | Rent (activate) one or more phone numbers by providing them in E.164 format. <br> _Example prompt_: "Rent the phone number +12025551234."                                                          | numbers |
 
 ### Configuration Tools
 
 | Tool                        | Description                                                                                                                                                                                           | Tags |
-|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------|
-| **sinch-mcp-configuration** | List all available tools in the Sinch MCP server and their status. If a tool is disabled, it will display the reason why. <br> *Example prompt*: "Which tools are available in the Sinch MCP server?" |      |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| **sinch-mcp-configuration** | List all available tools in the Sinch MCP server and their status. If a tool is disabled, it will display the reason why. <br> _Example prompt_: "Which tools are available in the Sinch MCP server?" |      |
 
 ## Getting Started
 
@@ -84,9 +83,10 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 ### API credentials
 
 To use the APIs used by the MCP tools, you will need the following credentials:
+
 - Conversation / Numbers API credentials:
   - (Required) `PROJECT_ID`: Select the project you want to use from your [Sinch Build dashboard](https://dashboard.sinch.com/dashboard) (Located at the left of the top toolbar)
-![Project ID selection](./docs/projectId-selection.png)
+    ![Project ID selection](./docs/projectId-selection.png)
   - (Required) `KEY_ID`: Select or create a new access key in the [Access keys section](https://dashboard.sinch.com/settings/access-keys) of the Sinch Build dashboard.
   - (Required) `KEY_SECRET`: This is the secret associated with the `Access Key` you selected or created in the previous step. Be careful, the `Access Key Secret` is only shown once when you create the `Access Key`. If you lose it, you will need to create a new `Access Key`.
   - `CONVERSATION_APP_ID`: This is the ID of the conversation app you want to use. You can find it in the [Conversation API / Apps section](https://dashboard.sinch.com/convapi/apps) of the Sinch Build dashboard. If you don't set it, you will have to specify it in the prompt.
@@ -114,10 +114,7 @@ The Sinch MCP server is available as an NPM package to the executed. Here is how
   "mcpServers": {
     "sinch": {
       "command": "npx",
-      "args": [
-        "-y",
-        "@sinch/mcp"
-      ],
+      "args": ["-y", "@sinch/mcp"],
       "env": {
         "PROJECT_ID": "",
         "KEY_ID": "",
@@ -137,8 +134,6 @@ The Sinch MCP server is available as an NPM package to the executed. Here is how
   }
 }
 ```
-
-
 
 # Running the MCP Server locally
 
@@ -169,9 +164,7 @@ Here is an example of how to configure the MCP server in the [Claude Desktop](ht
   "mcpServers": {
     "sinch": {
       "command": "node",
-      "args": [
-        "/your/path/to/sinch-mcp-server/dist/index.js"
-      ],
+      "args": ["/your/path/to/sinch-mcp-server/dist/index.js"],
       "env": {
         "PROJECT_ID": "",
         "KEY_ID": "",
@@ -196,30 +189,34 @@ Here is an example of how to configure the MCP server in the [Claude Desktop](ht
 
 Too many tools mean bigger context, mean higher tokens usage and more confusion for the LLM to select the right tool to use.<br>
 You can filter the tools that are available in the MCP server by using the `tags` options. For example, if you want to only use the conversation tools, you can add the following options to the `args` array:
+
 ```
       "args": [
         "/your/path/to/sinch-mcp-server/dist/index.js",
-        "--tags", 
+        "--tags",
         "conversation"
       ],
 ```
+
 You can combine multiple tags by separating them with commas. For example, if you want to use both conversation and verification tools, you can use the following command:
+
 ```
       "args": [
         "/your/path/to/sinch-mcp-server/dist/index.js",
-        "--tags", 
+        "--tags",
         "conversation,verification"
       ],
 ```
+
 If you want to use all the tools, you can omit the `--tags` option, or use the tag `all`:
+
 ```
       "args": [
         "/your/path/to/sinch-mcp-server/dist/index.js",
-        "--tags", 
+        "--tags",
         "all"
       ],
 ```
-
 
 ## Option 2: Start the MCP server remotely and connect to it using SSE
 
@@ -237,6 +234,7 @@ npm run build
 ### Step 2: Set up the MCP server configuration
 
 Copy the file `.template.env` and rename it `.env`. Then replace the placeholders with your own credentials and delete any key you don't need. The `.env` file should look like this ():
+
 ```dotenv
 # Conversation / Numbers tools related environment variables
 PROJECT_ID=
@@ -270,6 +268,7 @@ npm run start:stdio
 ```
 
 By default, this command will start the MCP with all the tools available. If you want to filter the tools that are available in the MCP server, you can use the `--tags` option. For example, if you want to only use the conversation tools, you can modify the command as follows:
+
 ```bash
 # Original command
 "start:sse": "tsc --project tsconfig.build.json && (npx -y supergateway --stdio \"node dist/index.js\" --port 8000 --baseUrl http://localhost:8000 --ssePath /sse --messagePath /message)"
@@ -279,6 +278,7 @@ By default, this command will start the MCP with all the tools available. If you
 ```
 
 You can combine multiple tags by separating them with commas. For example, if you want to use both conversation and verification tools, you can use the following command:
+
 ```bash
 "start": "tsc --project tsconfig.build.json && (npx -y supergateway --stdio \"node dist/index.js --tag conversation,verification\" --port 8000 --baseUrl http://localhost:8000 --ssePath /sse --messagePath /message)"
 ```
@@ -286,20 +286,19 @@ You can combine multiple tags by separating them with commas. For example, if yo
 ### Step 4: Configure the MCP server in Claude Desktop
 
 You can then configure the MCP server in the Claude configuration file as follows:
+
 ```json
 {
   "mcpServers": {
     "sinch": {
       "command": "npx",
-      "args": [
-        "-y", "supergateway", "--sse", "http://localhost:8000/sse"
-      ]
+      "args": ["-y", "supergateway", "--sse", "http://localhost:8000/sse"]
     }
   }
 }
 ```
-(Replace the `http://localhost:8000/sse` with the URL of your MCP server if it is not running locally)
 
+(Replace the `http://localhost:8000/sse` with the URL of your MCP server if it is not running locally)
 
 ## Contributing: Defining new tools
 
@@ -315,12 +314,14 @@ Dependencies are pinned to **exact versions** in `package.json` (no `^` ranges).
 When bumping `@modelcontextprotocol/sdk` or `zod`, test the server startup and your transport path (stdio, SSE, or Streamable HTTP) — some version combinations have been problematic in the past.
 
 Tools are registered in the `src/index.ts` file.
+
 - Conversation tools: send various types of messages, list conversation apps, templates
 - Verification tools: lookup for a number, perform a verification flow
 - Voice tools: make a TTS call, create a conference call, manage participants
 - Email tools: send emails, retrieve email information
 
 Tools are defined under `src/tools/` and are registered in the `index.ts` file of their respective domain folder.
+
 - Conversation tools: `src/tools/conversation/index.ts`
 - Verification tools: `src/tools/verification/index.ts`
 - Voice tools: `src/tools/voice/index.ts`

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 
 ### Numbers Tools
 
-| Tool                             | Description                                                                                                                                                                                        | Tags    |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| **list-available-regions**       | List all regions where phone numbers are available for the project. Can filter by number type (MOBILE, LOCAL, TOLL_FREE). <br> _Example prompt_: "Which regions have toll-free numbers available?" | numbers |
-| **list-rented-numbers**          | List all active (rented) phone numbers for the project. Can filter by region, type, pattern, and capability. <br> _Example prompt_: "Show me all my active phone numbers in the US."               | numbers |
-| **search-for-available-numbers** | Search for phone numbers available to rent, with filters for region, type, pattern, and capabilities. <br> _Example prompt_: "Find available local numbers in the US that support SMS."            | numbers |
-| **rent-sinch-virtual-numbers**   | Rent (activate) one or more phone numbers by providing them in E.164 format. <br> _Example prompt_: "Rent the phone number +12025551234."                                                          | numbers |
+| Tool                             | Description                                                                                                                                                                                              | Tags    |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| **list-available-regions**       | List all regions where phone numbers are available for the project. Can filter by number type (`MOBILE`, `LOCAL`, `TOLL_FREE`). <br> _Example prompt_: "Which regions have toll-free numbers available?" | numbers |
+| **list-rented-numbers**          | List all active (rented) phone numbers for the project. Can filter by region, type, pattern, and capability. <br> _Example prompt_: "Show me all my active phone numbers in the US."                     | numbers |
+| **search-for-available-numbers** | Search for phone numbers available to rent, with filters for region, type, pattern, and capabilities. <br> _Example prompt_: "Find available local numbers in the US that support SMS."                  | numbers |
+| **rent-sinch-virtual-numbers**   | Rent (activate) one or more phone numbers by providing them in E.164 format. <br> _Example prompt_: "Rent the phone number +12025551234."                                                                | numbers |
 
 ### Configuration Tools
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import js from '@eslint/js';
-import eslintPluginPrettierRecommended from 'eslint-config-prettier';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import eslintPluginPrettier from 'eslint-plugin-prettier';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import parser from '@typescript-eslint/parser';
 import jest from 'eslint-plugin-jest';
@@ -28,16 +29,14 @@ export default [
       jest,
       'jest-formatting': jestFormatting,
       'jest-extended': jestExtended,
+      'prettier': eslintPluginPrettier,
     },
     rules: {
       ...typescriptEslint.configs.recommended.rules,
+      ...eslintConfigPrettier.rules,
 
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-var-requires': 'off',
-
-      'semi': 'warn',
-      'comma-dangle': 'warn',
-      'quotes': ['warn', 'single'],
 
       'jest-extended/prefer-to-be-true': 'warn',
       'jest-extended/prefer-to-be-false': 'error',
@@ -46,30 +45,9 @@ export default [
       'jest/expect-expect': 'error',
 
       'curly': ['error', 'all'],
-      'indent': ['error', 2],
-      'object-curly-spacing': [
-        'error',
-        'always',
-        {
-          objectsInObjects: true,
-          arraysInObjects: true,
-        },
-      ],
       'require-jsdoc': 'off',
-      'operator-linebreak': ['error', 'before'],
-      'max-len': [
-        'error',
-        {
-          code: 120,
-          ignoreUrls: true,
-          ignoreComments: true,
-          ignoreTemplateLiterals: true,
-          ignoreRegExpLiterals: true,
-          ignorePattern: '^import.+|test',
-        },
-      ],
       'new-cap': 'off',
+      'prettier/prettier': 'warn',
     },
-  },
-  eslintPluginPrettierRecommended,
+  }
 ];

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,11 +1,14 @@
-import type {Config} from 'jest';
+import type { Config } from 'jest';
 
 const config: Config = {
   preset: 'ts-jest',
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', {
-      tsconfig: 'tsconfig.tests.json',
-    }],
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.tests.json',
+      },
+    ],
   },
   testEnvironment: 'node',
   roots: ['<rootDir>/src', '<rootDir>/tests'],

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "start:stdio": "tsc && node dist/index.js",
     "start:sse": "tsc --project tsconfig.build.json && npx -y supergateway --stdio \"node dist/index.js\" --port 8000 --baseUrl http://localhost:8000 --ssePath /sse --messagePath /message",
     "start:http": "tsc --project tsconfig.build.json && npx -y supergateway --stdio \"node dist/index.js\" --port 8000 --outputTransport streamableHttp",
-    "lint": "eslint src/ tests/ --ext .ts",
+    "lint": "eslint src/ tests/ --ext .ts --max-warnings 0",
     "lint:fix": "eslint src/ tests/ --ext .ts --fix",
     "prettier": "prettier './**/*.{js,ts,md}' --write",
     "format": "npm run lint:fix && npm run prettier",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
     "start:sse": "tsc --project tsconfig.build.json && npx -y supergateway --stdio \"node dist/index.js\" --port 8000 --baseUrl http://localhost:8000 --ssePath /sse --messagePath /message",
     "start:http": "tsc --project tsconfig.build.json && npx -y supergateway --stdio \"node dist/index.js\" --port 8000 --outputTransport streamableHttp",
     "lint": "eslint src/ tests/ --ext .ts",
+    "lint:fix": "eslint src/ tests/ --ext .ts --fix",
     "prettier": "prettier './**/*.{js,ts,md}' --write",
+    "format": "npm run lint:fix && npm run prettier",
     "test": "jest --testPathIgnorePatterns='/tests/integration/'",
     "test:integration": "jest tests/integration/llms --runInBand"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,6 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import dotenv from 'dotenv';
-import {
-  instantiateMcpServer,
-  parseArgs,
-  registerCapabilities,
-} from './server';
+import { instantiateMcpServer, parseArgs, registerCapabilities } from './server';
 dotenv.config();
 
 export const main = async () => {

--- a/src/prompts/conversation/app-id.ts
+++ b/src/prompts/conversation/app-id.ts
@@ -12,9 +12,7 @@ export const registerAppId = (server: McpServer, tags: Tags[]) => {
     'conversation-app-id',
     {
       argsSchema: {
-        appId: z
-          .string()
-          .describe('The ID of the app to use for the Sinch conversation API'),
+        appId: z.string().describe('The ID of the app to use for the Sinch conversation API'),
       },
     },
     ({ appId }) => ({

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -4,4 +4,4 @@ import { Tags } from '../types';
 
 export const registerPrompts = (server: McpServer, tags: Tags[]) => {
   registerAppId(server, tags);
-}
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,20 +15,20 @@ export const instantiateMcpServer = () => {
     capabilities: {
       resources: {},
       tools: {},
-      prompts: {}
-    }
-  })
+      prompts: {},
+    },
+  });
 };
 
 export const parseArgs = (args: string[]): Tags[] => {
   const args1 = args.slice(2);
-  return args1.includes('--tags')
-      ? args1[args1.indexOf('--tags') + 1].split(',')
-      : [];
-}
+  return args1.includes('--tags') ? args1[args1.indexOf('--tags') + 1].split(',') : [];
+};
 
 export const registerCapabilities = (server: McpServer, tags: Tags[]) => {
-  if ( tags.length === 0) tags.push('all')
+  if (tags.length === 0) {
+    tags.push('all');
+  }
 
   // Register the prompts
   registerPrompts(server, tags);
@@ -39,4 +39,4 @@ export const registerCapabilities = (server: McpServer, tags: Tags[]) => {
   registerVoiceTools(server, tags);
   registerEmailTools(server, tags);
   registerNumbersTools(server, tags);
-}
+};

--- a/src/tools/conversation/create-conversation-app.ts
+++ b/src/tools/conversation/create-conversation-app.ts
@@ -1,10 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
-import {
-  getConversationService,
-  setConversationRegion,
-} from './utils/conversation-service-helper';
+import { getConversationService, setConversationRegion } from './utils/conversation-service-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import { formatAppResponse } from './utils/format-app-response';
 import { appendRegionHint } from './utils/region-hint';
@@ -12,8 +9,7 @@ import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { ConversationRegionOverride } from './prompt-schemas';
 
 const CreateConversationAppSchema = {
-  displayName: z.string()
-    .describe('Display name for the Conversation API app.'),
+  displayName: z.string().describe('Display name for the Conversation API app.'),
   region: ConversationRegionOverride,
 };
 
@@ -23,12 +19,15 @@ const TOOL_KEY: ConversationToolKey = 'createConversationApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerCreateConversationApp = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Create a new Conversation API app in the project. No channels are configured at creation; use set-sms-channel-on-app, set-rcs-channel-on-app, or set-whatsapp-channel-on-app to configure channels later. Read the conversation-app-setup resource for the full flow.',
+      description:
+        'Create a new Conversation API app in the project. No channels are configured at creation; use set-sms-channel-on-app, set-rcs-channel-on-app, or set-whatsapp-channel-on-app to configure channels later. Read the conversation-app-setup resource for the full flow.',
       inputSchema: CreateConversationAppSchema,
     },
     createConversationAppHandler,
@@ -54,14 +53,18 @@ export const createConversationAppHandler = async ({
       },
     });
 
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      app: formatAppResponse(response),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        app: formatAppResponse(response),
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: appendRegionHint(error, usedRegion),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: appendRegionHint(error, usedRegion),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/create-webhook.ts
+++ b/src/tools/conversation/create-webhook.ts
@@ -6,11 +6,7 @@ import {
   setConversationRegion,
 } from './utils/conversation-service-helper';
 import { formatWebhook } from './utils/format-webhook-response';
-import {
-  appendRegionHint,
-  buildDormantTriggersWarning,
-  hasNoTriggers,
-} from './utils/webhook-tools-helper';
+import { appendRegionHint, buildDormantTriggersWarning, hasNoTriggers } from './utils/webhook-tools-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import {
   ConversationAppIdOverride,
@@ -25,12 +21,15 @@ const TOOL_KEY: ConversationToolKey = 'createWebhook';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerCreateWebhook = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Create a webhook for a Conversation app (up to 5 per app). Events are delivered to the target URL over HTTP when triggers fire. Configure the signing secret in the Sinch Dashboard; it is not set through this tool.',
+      description:
+        'Create a webhook for a Conversation app (up to 5 per app). Events are delivered to the target URL over HTTP when triggers fire. Configure the signing secret in the Sinch Dashboard; it is not set through this tool.',
       inputSchema: {
         target: WebhookTarget,
         appId: ConversationAppIdOverride,
@@ -78,17 +77,22 @@ export const createWebhookHandler = async ({
       webhookCreateRequestBody,
     });
     const formatted = formatWebhook(response);
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      webhook: formatted,
-      ...(hasNoTriggers(triggers) && formatted.id && {
-        warning: buildDormantTriggersWarning(formatted.id),
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        webhook: formatted,
+        ...(hasNoTriggers(triggers) &&
+          formatted.id && {
+            warning: buildDormantTriggersWarning(formatted.id),
+          }),
       }),
-    })).promptResponse;
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: appendRegionHint(error, usedRegion),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: appendRegionHint(error, usedRegion),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/delete-webhook.ts
+++ b/src/tools/conversation/delete-webhook.ts
@@ -1,8 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import {
-  getConversationService,
-  setConversationRegion,
-} from './utils/conversation-service-helper';
+import { getConversationService, setConversationRegion } from './utils/conversation-service-helper';
 import { appendRegionHint } from './utils/webhook-tools-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import { ConversationRegionOverride, WebhookId } from './prompt-schemas';
@@ -13,7 +10,9 @@ const TOOL_KEY: ConversationToolKey = 'deleteWebhook';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerDeleteWebhook = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -46,14 +45,18 @@ export const deleteWebhookHandler = async ({
     await conversationService.webhooks.delete({
       webhook_id: webhookId,
     });
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      webhook_id: webhookId,
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        webhook_id: webhookId,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: appendRegionHint(error, usedRegion),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: appendRegionHint(error, usedRegion),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/get-webhook.ts
+++ b/src/tools/conversation/get-webhook.ts
@@ -1,8 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import {
-  getConversationService,
-  setConversationRegion,
-} from './utils/conversation-service-helper';
+import { getConversationService, setConversationRegion } from './utils/conversation-service-helper';
 import { formatWebhook } from './utils/format-webhook-response';
 import { appendRegionHint } from './utils/webhook-tools-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
@@ -14,12 +11,15 @@ const TOOL_KEY: ConversationToolKey = 'getWebhook';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerGetWebhook = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Get a Conversation API webhook by its ID. Signing secrets are not returned; configure them in the Sinch Dashboard.',
+      description:
+        'Get a Conversation API webhook by its ID. Signing secrets are not returned; configure them in the Sinch Dashboard.',
       inputSchema: {
         webhookId: WebhookId,
         region: ConversationRegionOverride,
@@ -47,14 +47,18 @@ export const getWebhookHandler = async ({
     const response = await conversationService.webhooks.get({
       webhook_id: webhookId,
     });
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      webhook: formatWebhook(response),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        webhook: formatWebhook(response),
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: appendRegionHint(error, usedRegion),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: appendRegionHint(error, usedRegion),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/list-all-apps.ts
+++ b/src/tools/conversation/list-all-apps.ts
@@ -10,19 +10,21 @@ const TOOL_KEY: ConversationToolKey = 'listConversationApps';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListAllApps = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Get a list of all Conversation apps in the account. Apps are created and configured in the Sinch Dashboard or with the Conversation API. The App is the entity that holds the credentials related to the various channels',
+      description:
+        'Get a list of all Conversation apps in the account. Apps are created and configured in the Sinch Dashboard or with the Conversation API. The App is the entity that holds the credentials related to the various channels',
     },
-    listAllAppsHandler
+    listAllAppsHandler,
   );
 };
 
 export const listAllAppsHandler = async (): Promise<IPromptResponse> => {
-
   const maybeService = getConversationService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;
@@ -41,29 +43,35 @@ export const listAllAppsHandler = async (): Promise<IPromptResponse> => {
         const response = await conversationService.app.list({});
         const formatted = formatListAllAppsResponse(response);
         if (formatted.apps && formatted.apps.length > 0) {
-          allApps.push(...formatted.apps.map((app: any) => ({
-            ...app,
-            region
-          })));
+          allApps.push(
+            ...formatted.apps.map((app: any) => ({
+              ...app,
+              region,
+            })),
+          );
         }
       } catch (error) {
         errors.push({
           region,
-          error: error instanceof Error ? error.message : 'Unknown error'
+          error: error instanceof Error ? error.message : 'Unknown error',
         });
       }
     }
 
-    return new PromptResponse(JSON.stringify({
-      success: errors.length === 0,
-      apps: allApps,
-      total_count: allApps.length,
-      ...(errors.length > 0 && { errors })
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: errors.length === 0,
+        apps: allApps,
+        total_count: allApps.length,
+        ...(errors.length > 0 && { errors }),
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : 'Unknown error'
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/list-messaging-templates.ts
+++ b/src/tools/conversation/list-messaging-templates.ts
@@ -11,14 +11,17 @@ const TOOL_KEY: ConversationToolKey = 'listMessagingTemplates';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListAllTemplates = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Get a list of all messaging-related templates (omni-channel or channel specific) belonging to an account. Note that the Email templates are NOT included in this list - they can be found with another tool: list-email-templates. Do not try to use this tool to list Email templates, it will not work.',
+      description:
+        'Get a list of all messaging-related templates (omni-channel or channel specific) belonging to an account. Note that the Email templates are NOT included in this list - they can be found with another tool: list-email-templates. Do not try to use this tool to list Email templates, it will not work.',
     },
-    listAllTemplatesHandler
+    listAllTemplatesHandler,
   );
 };
 
@@ -39,31 +42,35 @@ export const listAllTemplatesHandler = async (): Promise<IPromptResponse> => {
         setTemplateRegion(region, conversationService);
         const response = await conversationService.templatesV2.list({});
         const formatted = formatListAllTemplatesResponse(response);
-        omniChannelTemplates.push(...formatted.map(t => ({ ...t, region })));
+        omniChannelTemplates.push(...formatted.map((t) => ({ ...t, region })));
       } catch (error) {
         errors.push({
           region,
-          error: error instanceof Error ? error.message : 'Unknown error'
+          error: error instanceof Error ? error.message : 'Unknown error',
         });
       }
     }
 
     const whatsAppTemplates = await fetchWhatsAppSpecificTemplates();
 
-    return new PromptResponse(JSON.stringify({
-      success: errors.length === 0,
-      templates: {
-        omni_channel: omniChannelTemplates,
-        whatsapp: whatsAppTemplates,
-        ...(errors.length > 0 && { errors })
-      },
-      total_count: omniChannelTemplates.length + whatsAppTemplates.length
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: errors.length === 0,
+        templates: {
+          omni_channel: omniChannelTemplates,
+          whatsapp: whatsAppTemplates,
+          ...(errors.length > 0 && { errors }),
+        },
+        total_count: omniChannelTemplates.length + whatsAppTemplates.length,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 };
 
@@ -85,9 +92,9 @@ const fetchWhatsAppSpecificTemplates = async () => {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: 'Basic ' + Buffer.from(`${process.env.KEY_ID}:${process.env.KEY_SECRET}`).toString('base64')
-      }
-    }
+        Authorization: 'Basic ' + Buffer.from(`${process.env.KEY_ID}:${process.env.KEY_SECRET}`).toString('base64'),
+      },
+    },
   );
 
   if (!resp.ok) {

--- a/src/tools/conversation/list-webhooks.ts
+++ b/src/tools/conversation/list-webhooks.ts
@@ -15,12 +15,15 @@ const TOOL_KEY: ConversationToolKey = 'listWebhooks';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListWebhooks = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'List all webhooks configured for a Conversation app. Webhooks receive Conversation API callbacks at a target URL when selected triggers occur. Configure signing secrets in the Sinch Dashboard.',
+      description:
+        'List all webhooks configured for a Conversation app. Webhooks receive Conversation API callbacks at a target URL when selected triggers occur. Configure signing secrets in the Sinch Dashboard.',
       inputSchema: {
         appId: ConversationAppIdOverride,
         region: ConversationRegionOverride,
@@ -55,15 +58,19 @@ export const listWebhooksHandler = async ({
       app_id: conversationAppId,
     });
     const formatted = formatListWebhooksResponse(response);
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      ...formatted,
-      total_count: formatted.webhooks.length,
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        ...formatted,
+        total_count: formatted.webhooks.length,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: appendRegionHint(error, usedRegion),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: appendRegionHint(error, usedRegion),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/prompt-schemas/index.ts
+++ b/src/tools/conversation/prompt-schemas/index.ts
@@ -1,39 +1,70 @@
 import { z } from 'zod';
 import { SupportedConversationRegion } from '@sinch/sdk-client';
 
-export const Recipient = z.string()
-  .describe('(Required) The recipient to send the message to. This can be a phone number in E.164 format, or the identifier for the specified channel such as Messenger.');
+export const Recipient = z
+  .string()
+  .describe(
+    '(Required) The recipient to send the message to. This can be a phone number in E.164 format, or the identifier for the specified channel such as Messenger.',
+  );
 
 export const ChannelEnum = z.enum([
-  'WHATSAPP', 'RCS', 'SMS', 'MESSENGER', 'VIBERBM',
-  'MMS', 'INSTAGRAM', 'TELEGRAM', 'KAKAOTALK', 'KAKAOTALKCHAT',
-  'LINE', 'WECHAT', 'APPLEBC'
+  'WHATSAPP',
+  'RCS',
+  'SMS',
+  'MESSENGER',
+  'VIBERBM',
+  'MMS',
+  'INSTAGRAM',
+  'TELEGRAM',
+  'KAKAOTALK',
+  'KAKAOTALKCHAT',
+  'LINE',
+  'WECHAT',
+  'APPLEBC',
 ]);
 
-export const ConversationChannel = z.array(ChannelEnum).nonempty()
-  .describe('(Required) The channel to use for sending the message.')
+export const ConversationChannel = z
+  .array(ChannelEnum)
+  .nonempty()
+  .describe('(Required) The channel to use for sending the message.');
 
-export const ConversationAppIdOverride = z.string().optional()
-  .describe('(Optional) The ID of the app to use for the Sinch conversation API. If set, it will override the value from the environment variable "CONVERSATION_APP_ID".')
+export const ConversationAppIdOverride = z
+  .string()
+  .optional()
+  .describe(
+    '(Optional) The ID of the app to use for the Sinch conversation API. If set, it will override the value from the environment variable "CONVERSATION_APP_ID".',
+  );
 
-export const ConversationAppId = z.string()
-  .describe('The Conversation API app ID. Use list-conversation-apps to find existing app IDs.')
+export const ConversationAppId = z
+  .string()
+  .describe('The Conversation API app ID. Use list-conversation-apps to find existing app IDs.');
 
-export const MessageSenderNumberOverride = z.string().optional()
-  .describe('(Optional) The phone number of the message\'s sender (E.164 format). If set, it will override the value from the environment variable "DEFAULT_SMS_ORIGINATOR".')
+export const MessageSenderNumberOverride = z
+  .string()
+  .optional()
+  .describe(
+    '(Optional) The phone number of the message\'s sender (E.164 format). If set, it will override the value from the environment variable "DEFAULT_SMS_ORIGINATOR".',
+  );
 
 const supportedRegions = Object.values(SupportedConversationRegion) as [string, ...string[]];
-export const ConversationRegionOverride = z.enum([...supportedRegions, '']).optional()
-  .describe('(Optional) The region to use for the Sinch conversation API. If set, it will override the value from the environment variable CONVERSATION_REGION.')
+export const ConversationRegionOverride = z
+  .enum([...supportedRegions, ''])
+  .optional()
+  .describe(
+    '(Optional) The region to use for the Sinch conversation API. If set, it will override the value from the environment variable CONVERSATION_REGION.',
+  );
 
-export const TextMessage = z.string()
-  .describe('(Required) The text to send.')
+export const TextMessage = z.string().describe('(Required) The text to send.');
 
-export const WebhookId = z.string()
-  .describe('(Required) The ID of the webhook. You can obtain it from list-webhooks or the Sinch Dashboard.')
+export const WebhookId = z
+  .string()
+  .describe('(Required) The ID of the webhook. You can obtain it from list-webhooks or the Sinch Dashboard.');
 
-export const WebhookTarget = z.string()
-  .describe('(Required) The HTTPS URL where Conversation API events should be delivered. Maximum length is 742 characters.')
+export const WebhookTarget = z
+  .string()
+  .describe(
+    '(Required) The HTTPS URL where Conversation API events should be delivered. Maximum length is 742 characters.',
+  );
 
 const webhookTriggerValues = [
   'MESSAGE_DELIVERY',
@@ -58,8 +89,13 @@ const webhookTriggerValues = [
   'RECORD_NOTIFICATION',
 ] as const;
 
-export const WebhookTriggers = z.array(z.enum(webhookTriggerValues)).optional()
-  .describe('(Optional) Event triggers that activate this webhook. Omit to leave without triggers, or pass an empty array [] to clear all triggers on update. Use update-webhook to add triggers later.')
+export const WebhookTriggers = z
+  .array(z.enum(webhookTriggerValues))
+  .optional()
+  .describe(
+    '(Optional) Event triggers that activate this webhook. Omit to leave without triggers, or pass an empty array [] to clear all triggers on update. Use update-webhook to add triggers later.',
+  );
 
-export const WebhookTargetOptional = WebhookTarget.optional()
-  .describe('(Optional) The HTTPS URL where Conversation API events should be delivered.')
+export const WebhookTargetOptional = WebhookTarget.optional().describe(
+  '(Optional) The HTTPS URL where Conversation API events should be delivered.',
+);

--- a/src/tools/conversation/resources/register-conversation-resources.ts
+++ b/src/tools/conversation/resources/register-conversation-resources.ts
@@ -1,10 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Tags } from '../../../types';
 import { matchesAnyTag } from '../../../utils';
-import {
-  CONVERSATION_APP_SETUP_URI,
-  conversationAppSetupGuide,
-} from './conversation-app-setup-guide';
+import { CONVERSATION_APP_SETUP_URI, conversationAppSetupGuide } from './conversation-app-setup-guide';
 
 const RESOURCE_TAGS: Tags[] = [
   'all',
@@ -17,7 +14,9 @@ const RESOURCE_TAGS: Tags[] = [
 ];
 
 export const registerConversationResources = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, RESOURCE_TAGS)) return;
+  if (!matchesAnyTag(tags, RESOURCE_TAGS)) {
+    return;
+  }
 
   server.registerResource(
     'conversation-app-setup',
@@ -27,11 +26,13 @@ export const registerConversationResources = (server: McpServer, tags: Tags[]) =
       mimeType: 'text/markdown',
     },
     async () => ({
-      contents: [{
-        uri: CONVERSATION_APP_SETUP_URI,
-        mimeType: 'text/markdown',
-        text: conversationAppSetupGuide,
-      }],
+      contents: [
+        {
+          uri: CONVERSATION_APP_SETUP_URI,
+          mimeType: 'text/markdown',
+          text: conversationAppSetupGuide,
+        },
+      ],
     }),
   );
 };

--- a/src/tools/conversation/send-card-or-choice-message.ts
+++ b/src/tools/conversation/send-card-or-choice-message.ts
@@ -19,27 +19,33 @@ import {
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 
-const choiceMessage = z.object({
-  // Call
-  phone_number: z.string().optional().describe('E.164 format'),
-  // Location
-  lat: z.number().optional(),
-  long: z.number().optional(),
-  address: z.string().optional(),
-  // Text
-  text: z.string().optional(),
-  // URL
-  url: z.string().url().optional(),
-  // Common
-  title: z.string().optional()
-}).refine(
-  data =>
-    Number(!!data.text) +
-    Number(!!data.url) +
-    Number(!!data.phone_number) +
-    Number((!!data.lat && !!data.long) || !!data.address) === 1,
-  { message: 'Must provide exactly one type of choice: call, location, text, or URL' }
-).describe('Choice message that can be a call, location, text, or URL. Exactly one must be provided. The "title" parameter must not be provided is case of text choice.');
+const choiceMessage = z
+  .object({
+    // Call
+    phone_number: z.string().optional().describe('E.164 format'),
+    // Location
+    lat: z.number().optional(),
+    long: z.number().optional(),
+    address: z.string().optional(),
+    // Text
+    text: z.string().optional(),
+    // URL
+    url: z.string().url().optional(),
+    // Common
+    title: z.string().optional(),
+  })
+  .refine(
+    (data) =>
+      Number(!!data.text) +
+        Number(!!data.url) +
+        Number(!!data.phone_number) +
+        Number((!!data.lat && !!data.long) || !!data.address) ===
+      1,
+    { message: 'Must provide exactly one type of choice: call, location, text, or URL' },
+  )
+  .describe(
+    'Choice message that can be a call, location, text, or URL. Exactly one must be provided. The "title" parameter must not be provided is case of text choice.',
+  );
 
 const SendCardOrChoiceMessageSchema = {
   recipient: Recipient,
@@ -58,15 +64,18 @@ const TOOL_KEY: ConversationToolKey = 'sendCardOrChoiceMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendCardOrChoiceMessage = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Send a choice message to the user. The choice message can contain up to 3 choices if not text or up to 10 message if text only. Each choice can be a call message (phone number + title to display next to it), a location message (latitude / longitude + title to display next to it), a text message or a URL message (the URL to click on + title to display next to it). The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      description:
+        'Send a choice message to the user. The choice message can contain up to 3 choices if not text or up to 10 message if text only. Each choice can be a call message (phone number + title to display next to it), a location message (latitude / longitude + title to display next to it), a text message or a URL message (the URL to click on + title to display next to it). The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
       inputSchema: SendCardOrChoiceMessageSchema,
     },
-    sendCardOrChoiceMessageHandler
+    sendCardOrChoiceMessageHandler,
   );
 };
 
@@ -78,7 +87,7 @@ export const sendCardOrChoiceMessageHandler = async ({
   mediaUrl,
   appId,
   sender,
-  region
+  region,
 }: SendCardOrChoiceMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
@@ -99,18 +108,18 @@ export const sendCardOrChoiceMessageHandler = async ({
       choices.push({
         call_message: {
           phone_number: choice.phone_number,
-          title: choice.title
-        }
+          title: choice.title,
+        },
       } as Conversation.CallMessageChoice);
     } else if ('lat' in choice && 'long' in choice) {
       choices.push({
         location_message: {
           coordinates: {
             latitude: choice.lat,
-            longitude: choice.long
+            longitude: choice.long,
           },
-          title: choice.title
-        }
+          title: choice.title,
+        },
       } as Conversation.LocationMessageChoice);
     } else if ('address' in choice && choice.address) {
       const coordinates = await getLatitudeLongitudeFromAddress(choice.address);
@@ -118,23 +127,23 @@ export const sendCardOrChoiceMessageHandler = async ({
         location_message: {
           coordinates: {
             latitude: coordinates.latitude,
-            longitude: coordinates.longitude
+            longitude: coordinates.longitude,
           },
-          title: coordinates.formattedAddress
-        }
+          title: coordinates.formattedAddress,
+        },
       } as Conversation.LocationMessageChoice);
     } else if ('text' in choice) {
       choices.push({
         text_message: {
-          text: choice.text
-        }
+          text: choice.text,
+        },
       } as Conversation.TextMessageChoice);
     } else if ('url' in choice) {
       choices.push({
         url_message: {
           url: choice.url,
-          title: choice.title
-        }
+          title: choice.title,
+        },
       } as Conversation.UrlMessageChoice);
     }
   }
@@ -152,11 +161,11 @@ export const sendCardOrChoiceMessageHandler = async ({
               choices,
               title: text,
               media_message: {
-                url: mediaUrl
-              }
-            }
-          }
-        }
+                url: mediaUrl,
+              },
+            },
+          },
+        },
       });
     } else {
       response = await conversationService.messages.sendChoiceMessage({
@@ -165,22 +174,28 @@ export const sendCardOrChoiceMessageHandler = async ({
           message: {
             choice_message: {
               choices,
-              text_message:{
-                text
-              }
-            }
-          }
-        }
+              text_message: {
+                text,
+              },
+            },
+          },
+        },
       });
     }
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      message_id: response.message_id
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        message_id: response.message_id,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error)) + `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error:
+          (error instanceof Error ? error.message : String(error)) +
+          `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`,
+      }),
+    ).promptResponse;
   }
-}
+};

--- a/src/tools/conversation/send-location-message.ts
+++ b/src/tools/conversation/send-location-message.ts
@@ -6,11 +6,7 @@ import {
   getConversationService,
   setConversationRegion,
 } from './utils/conversation-service-helper';
-import {
-  ConversationToolKey,
-  getToolName,
-  toolsConfig,
-} from './utils/conversation-tools-helper';
+import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import {
   Recipient,
   ConversationAppIdOverride,
@@ -46,16 +42,16 @@ type LocationMessage = z.infer<z.ZodObject<typeof LocationMessageSchema>>;
 const TOOL_KEY: ConversationToolKey = 'sendLocationMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
-export const registerSendLocationMessage = (
-  server: McpServer,
-  tags: Tags[],
-) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+export const registerSendLocationMessage = (server: McpServer, tags: Tags[]) => {
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Send a location message from an address given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      description:
+        'Send a location message from an address given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
       inputSchema: LocationMessageSchema,
     },
     sendLocationMessageHandler,
@@ -87,9 +83,7 @@ export const sendLocationMessageHandler = async ({
     longitude = 0;
   let formattedAddress = 'Default tile';
   if (address.address) {
-    const geocodingAddress = await getLatitudeLongitudeFromAddress(
-      address.address,
-    );
+    const geocodingAddress = await getLatitudeLongitudeFromAddress(address.address);
     latitude = geocodingAddress.latitude;
     longitude = geocodingAddress.longitude;
     formattedAddress = geocodingAddress.formattedAddress;
@@ -98,32 +92,24 @@ export const sendLocationMessageHandler = async ({
     longitude = address.long;
     formattedAddress = address.title;
   }
-  const requestBase = await buildMessageBase(
-    conversationService,
-    conversationAppId,
-    recipient,
-    channel,
-    sender,
-  );
-  const request: Conversation.SendLocationMessageRequestData<Conversation.IdentifiedBy> =
-    {
-      sendMessageRequestBody: {
-        ...requestBase,
-        message: {
-          location_message: {
-            coordinates: {
-              longitude,
-              latitude,
-            },
-            title: formattedAddress,
+  const requestBase = await buildMessageBase(conversationService, conversationAppId, recipient, channel, sender);
+  const request: Conversation.SendLocationMessageRequestData<Conversation.IdentifiedBy> = {
+    sendMessageRequestBody: {
+      ...requestBase,
+      message: {
+        location_message: {
+          coordinates: {
+            longitude,
+            latitude,
           },
+          title: formattedAddress,
         },
       },
-    };
+    },
+  };
 
   try {
-    const response =
-      await conversationService.messages.sendLocationMessage(request);
+    const response = await conversationService.messages.sendLocationMessage(request);
     return new PromptResponse(
       JSON.stringify({
         success: true,

--- a/src/tools/conversation/send-media-message.ts
+++ b/src/tools/conversation/send-media-message.ts
@@ -1,7 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Conversation } from '@sinch/conversation';
 import { z } from 'zod';
-import { Recipient, ConversationAppIdOverride, ConversationChannel, ConversationRegionOverride, MessageSenderNumberOverride } from './prompt-schemas';
+import {
+  Recipient,
+  ConversationAppIdOverride,
+  ConversationChannel,
+  ConversationRegionOverride,
+  MessageSenderNumberOverride,
+} from './prompt-schemas';
 import {
   getConversationAppId,
   getConversationService,
@@ -27,25 +33,28 @@ const TOOL_KEY: ConversationToolKey = 'sendMediaMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendMediaMessage = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Send a media message from URL given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel. The media must be specified with its URL.',
+      description:
+        'Send a media message from URL given in parameter to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel. The media must be specified with its URL.',
       inputSchema: SendMediaMessageSchema,
     },
-    sendMediaMessageHandler
+    sendMediaMessageHandler,
   );
 };
 
-export const sendMediaMessageHandler = async({
+export const sendMediaMessageHandler = async ({
   recipient,
   channel,
   url,
   appId,
   sender,
-  region
+  region,
 }: SendMediaMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
@@ -66,22 +75,28 @@ export const sendMediaMessageHandler = async({
       ...requestBase,
       message: {
         media_message: {
-          url: url
-        }
-      }
-    }
+          url: url,
+        },
+      },
+    },
   };
 
   try {
     const response = await conversationService.messages.sendMediaMessage(request);
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      message_id: response.message_id
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        message_id: response.message_id,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error)) + `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error:
+          (error instanceof Error ? error.message : String(error)) +
+          `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`,
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/send-template-message.ts
+++ b/src/tools/conversation/send-template-message.ts
@@ -10,16 +10,29 @@ import {
 } from './utils/conversation-service-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import { buildMessageBase } from './utils/send-message-builder';
-import { Recipient, ConversationAppIdOverride, ConversationChannel, ConversationRegionOverride, MessageSenderNumberOverride } from './prompt-schemas';
+import {
+  Recipient,
+  ConversationAppIdOverride,
+  ConversationChannel,
+  ConversationRegionOverride,
+  MessageSenderNumberOverride,
+} from './prompt-schemas';
 
 const SendTemplateMessageSchema = {
   recipient: Recipient,
-  templateId: z.string()
-    .describe('The ID (ULID format) of the omni-template template to use for sending the message.'),
-  language: z.string().optional()
-    .describe('The language to use for the omni-template (BCP-47). If not set, the default language code will be used.'),
-  parameters: z.record(z.string(), z.string()).optional()
-    .describe('The parameters to use for the template. This is a key-value map where the key is the parameter name and the value is the parameter value. Look carefully in the prompt to find which parameters are expected by the template.'),
+  templateId: z.string().describe('The ID (ULID format) of the omni-template template to use for sending the message.'),
+  language: z
+    .string()
+    .optional()
+    .describe(
+      'The language to use for the omni-template (BCP-47). If not set, the default language code will be used.',
+    ),
+  parameters: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      'The parameters to use for the template. This is a key-value map where the key is the parameter name and the value is the parameter value. Look carefully in the prompt to find which parameters are expected by the template.',
+    ),
   channel: ConversationChannel,
   appId: ConversationAppIdOverride,
   sender: MessageSenderNumberOverride,
@@ -32,15 +45,18 @@ const TOOL_KEY: ConversationToolKey = 'sendTemplateMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendTemplateMessage = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Send a template message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      description:
+        'Send a template message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
       inputSchema: SendTemplateMessageSchema,
     },
-    sendTemplateMessageHandler
+    sendTemplateMessageHandler,
   );
 };
 
@@ -52,7 +68,7 @@ export const sendTemplateMessageHandler = async ({
   parameters,
   appId,
   sender,
-  region
+  region,
 }: SendTemplateMessage): Promise<IPromptResponse> => {
   const maybeAppId = getConversationAppId(appId);
   if (isPromptResponse(maybeAppId)) {
@@ -73,9 +89,9 @@ export const sendTemplateMessageHandler = async ({
       template_id: templateId,
       version: 'latest',
       parameters: {
-        ...parameters
-      }
-    }
+        ...parameters,
+      },
+    },
   };
   if (language) {
     omniChannelMessage.omni_template!.language_code = language;
@@ -86,22 +102,28 @@ export const sendTemplateMessageHandler = async ({
       ...requestBase,
       message: {
         template_message: {
-          ...omniChannelMessage
-        }
-      }
-    }
+          ...omniChannelMessage,
+        },
+      },
+    },
   };
 
   try {
     const response = await conversationService.messages.sendTemplateMessage(request);
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      message_id: response.message_id
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        message_id: response.message_id,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error)) + `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error:
+          (error instanceof Error ? error.message : String(error)) +
+          `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`,
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/send-text-message.ts
+++ b/src/tools/conversation/send-text-message.ts
@@ -34,19 +34,22 @@ const TOOL_KEY: ConversationToolKey = 'sendTextMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendTextMessage = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Send a text message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
+      description:
+        'Send a text message to a contact on the specified channel. The contact can be a phone number in E.164 format, or the identifier for the specified channel.',
       inputSchema: SendTextMessageSchema,
     },
-    sendTextMessageHandler
+    sendTextMessageHandler,
   );
 };
 
-export const sendTextMessageHandler = async({
+export const sendTextMessageHandler = async ({
   recipient,
   channel,
   message,
@@ -73,22 +76,28 @@ export const sendTextMessageHandler = async({
       ...requestBase,
       message: {
         text_message: {
-          text: message
-        }
-      }
-    }
+          text: message,
+        },
+      },
+    },
   };
 
-  try{
+  try {
     const response = await conversationService.messages.sendTextMessage(request);
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      message_id: response.message_id
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        message_id: response.message_id,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error)) + `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error:
+          (error instanceof Error ? error.message : String(error)) +
+          `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`,
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/send-whatsapp-template-message.ts
+++ b/src/tools/conversation/send-whatsapp-template-message.ts
@@ -19,16 +19,23 @@ import {
 
 const SendWhatsAppTemplateMessageSchema = {
   recipient: Recipient,
-  templateName: z.string()
+  templateName: z
+    .string()
     .describe('The name of the template to use for sending the message on WhatsApp specifically.'),
-  templateLanguage: z.string()
-    .describe('The language to use for the WhatsApp template (BCP-47).'),
-  parameters: z.record(z.string(), z.string()).optional()
-    .describe('The parameters to use for the template. This is a key-value map where the key is the parameter name and the value is the parameter value. Look carefully in the prompt to find which parameters are expected by the template.'),
+  templateLanguage: z.string().describe('The language to use for the WhatsApp template (BCP-47).'),
+  parameters: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      'The parameters to use for the template. This is a key-value map where the key is the parameter name and the value is the parameter value. Look carefully in the prompt to find which parameters are expected by the template.',
+    ),
   appId: ConversationAppIdOverride,
   sender: MessageSenderNumberOverride,
   region: ConversationRegionOverride,
-  metadata: z.string().optional().describe('Custom data to send along with the message (e.g. correlation IDs, appointment IDs, etc.)'),
+  metadata: z
+    .string()
+    .optional()
+    .describe('Custom data to send along with the message (e.g. correlation IDs, appointment IDs, etc.)'),
 };
 
 type SendWhatsAppTemplateMessage = z.infer<z.ZodObject<typeof SendWhatsAppTemplateMessageSchema>>;
@@ -37,7 +44,9 @@ const TOOL_KEY: ConversationToolKey = 'sendWhatsAppTemplateMessage';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendWhatsAppTemplateMessage = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -45,7 +54,7 @@ export const registerSendWhatsAppTemplateMessage = (server: McpServer, tags: Tag
       description: 'Send a template message to a contact (phone number in E.164 format) on the WhatsApp channel.',
       inputSchema: SendWhatsAppTemplateMessageSchema,
     },
-    sendTemplateMessageHandler
+    sendTemplateMessageHandler,
   );
 };
 
@@ -80,33 +89,39 @@ export const sendTemplateMessageHandler = async ({
         language_code: templateLanguage,
         version: '',
         parameters: {
-          ...parameters
-        }
-      }
-    }
+          ...parameters,
+        },
+      },
+    },
   };
   const request: Conversation.SendTemplateMessageRequestData<Conversation.IdentifiedBy> = {
     sendMessageRequestBody: {
       ...requestBase,
       message: {
         template_message: {
-          ...whatsappMessage
-        }
+          ...whatsappMessage,
+        },
       },
-      message_metadata: metadata
-    }
+      message_metadata: metadata,
+    },
   };
 
   try {
     const response = await conversationService.messages.sendTemplateMessage(request);
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      message_id: response.message_id
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        message_id: response.message_id,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error)) + `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error:
+          (error instanceof Error ? error.message : String(error)) +
+          `. Are you sure you are using the right region to send your message? The current region is ${usedRegion}.`,
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/set-rcs-channel-on-app.ts
+++ b/src/tools/conversation/set-rcs-channel-on-app.ts
@@ -1,25 +1,17 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
-import {
-  getConversationService,
-  setConversationRegion,
-} from './utils/conversation-service-helper';
+import { getConversationService, setConversationRegion } from './utils/conversation-service-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import { buildRcsChannelCredential } from './utils/build-channel-credential';
 import { addChannelToApp } from './utils/app-tools-helper';
 import { IPromptResponse, Tags } from '../../types';
-import {
-  ConversationAppId,
-  ConversationRegionOverride,
-} from './prompt-schemas';
+import { ConversationAppId, ConversationRegionOverride } from './prompt-schemas';
 
 const SetRcsChannelOnAppSchema = {
   appId: ConversationAppId,
-  senderId: z.string()
-    .describe('RCS sender ID.'),
-  bearerToken: z.string()
-    .describe('Bearer token for the RCS channel.'),
+  senderId: z.string().describe('RCS sender ID.'),
+  bearerToken: z.string().describe('Bearer token for the RCS channel.'),
   region: ConversationRegionOverride,
 };
 
@@ -29,12 +21,15 @@ const TOOL_KEY: ConversationToolKey = 'setRcsChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSetRcsChannelOnApp = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Set (create or replace) the RCS channel on a Conversation API app. Requires the RCS sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
+      description:
+        'Set (create or replace) the RCS channel on a Conversation API app. Requires the RCS sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
       inputSchema: SetRcsChannelOnAppSchema,
     },
     setRcsChannelOnAppHandler,

--- a/src/tools/conversation/set-sms-channel-on-app.ts
+++ b/src/tools/conversation/set-sms-channel-on-app.ts
@@ -1,25 +1,17 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
-import {
-  getConversationService,
-  setConversationRegion,
-} from './utils/conversation-service-helper';
+import { getConversationService, setConversationRegion } from './utils/conversation-service-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import { buildSmsChannelCredential } from './utils/build-channel-credential';
 import { addChannelToApp } from './utils/app-tools-helper';
 import { IPromptResponse, Tags } from '../../types';
-import {
-  ConversationAppId,
-  ConversationRegionOverride,
-} from './prompt-schemas';
+import { ConversationAppId, ConversationRegionOverride } from './prompt-schemas';
 
 const SetSmsChannelOnAppSchema = {
   appId: ConversationAppId,
-  servicePlanId: z.string()
-    .describe('Sinch SMS service plan ID.'),
-  apiToken: z.string()
-    .describe('Sinch API token for the SMS service plan.'),
+  servicePlanId: z.string().describe('Sinch SMS service plan ID.'),
+  apiToken: z.string().describe('Sinch API token for the SMS service plan.'),
   region: ConversationRegionOverride,
 };
 
@@ -29,12 +21,15 @@ const TOOL_KEY: ConversationToolKey = 'setSmsChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSetSmsChannelOnApp = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Set (create or replace) the SMS channel on a Conversation API app. Requires the SMS service plan ID and API token. The app must be in the same region as the SMS service plan. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
+      description:
+        'Set (create or replace) the SMS channel on a Conversation API app. Requires the SMS service plan ID and API token. The app must be in the same region as the SMS service plan. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
       inputSchema: SetSmsChannelOnAppSchema,
     },
     setSmsChannelOnAppHandler,

--- a/src/tools/conversation/set-whatsapp-channel-on-app.ts
+++ b/src/tools/conversation/set-whatsapp-channel-on-app.ts
@@ -1,25 +1,17 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
-import {
-  getConversationService,
-  setConversationRegion,
-} from './utils/conversation-service-helper';
+import { getConversationService, setConversationRegion } from './utils/conversation-service-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
 import { buildWhatsAppChannelCredential } from './utils/build-channel-credential';
 import { addChannelToApp } from './utils/app-tools-helper';
 import { IPromptResponse, Tags } from '../../types';
-import {
-  ConversationAppId,
-  ConversationRegionOverride,
-} from './prompt-schemas';
+import { ConversationAppId, ConversationRegionOverride } from './prompt-schemas';
 
 const SetWhatsAppChannelOnAppSchema = {
   appId: ConversationAppId,
-  senderId: z.string()
-    .describe('WhatsApp sender ID.'),
-  bearerToken: z.string()
-    .describe('Bearer token for the WhatsApp channel.'),
+  senderId: z.string().describe('WhatsApp sender ID.'),
+  bearerToken: z.string().describe('Bearer token for the WhatsApp channel.'),
   region: ConversationRegionOverride,
 };
 
@@ -29,12 +21,15 @@ const TOOL_KEY: ConversationToolKey = 'setWhatsAppChannelOnApp';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSetWhatsAppChannelOnApp = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Set (create or replace) the WhatsApp channel on a Conversation API app. Requires the WhatsApp sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
+      description:
+        'Set (create or replace) the WhatsApp channel on a Conversation API app. Requires the WhatsApp sender ID and bearer token. For vague requests such as "add messaging", ask whether the user means SMS, RCS, or WhatsApp and collect the required credentials before calling a tool.',
       inputSchema: SetWhatsAppChannelOnAppSchema,
     },
     setWhatsAppChannelOnAppHandler,

--- a/src/tools/conversation/update-webhook.ts
+++ b/src/tools/conversation/update-webhook.ts
@@ -1,22 +1,10 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Conversation } from '@sinch/conversation';
-import {
-  getConversationService,
-  setConversationRegion,
-} from './utils/conversation-service-helper';
+import { getConversationService, setConversationRegion } from './utils/conversation-service-helper';
 import { formatWebhook } from './utils/format-webhook-response';
-import {
-  appendRegionHint,
-  buildDormantTriggersWarning,
-  hasNoTriggers,
-} from './utils/webhook-tools-helper';
+import { appendRegionHint, buildDormantTriggersWarning, hasNoTriggers } from './utils/webhook-tools-helper';
 import { ConversationToolKey, getToolName, toolsConfig } from './utils/conversation-tools-helper';
-import {
-  ConversationRegionOverride,
-  WebhookId,
-  WebhookTargetOptional,
-  WebhookTriggers,
-} from './prompt-schemas';
+import { ConversationRegionOverride, WebhookId, WebhookTargetOptional, WebhookTriggers } from './prompt-schemas';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
 import { isPromptResponse, matchesAnyTag } from '../../utils';
 
@@ -24,12 +12,15 @@ const TOOL_KEY: ConversationToolKey = 'updateWebhook';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerUpdateWebhook = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Update an existing Conversation API webhook. Provide at least one of target or triggers. Signing secrets are configured in the Sinch Dashboard, not through this tool.',
+      description:
+        'Update an existing Conversation API webhook. Provide at least one of target or triggers. Signing secrets are configured in the Sinch Dashboard, not through this tool.',
       inputSchema: {
         webhookId: WebhookId,
         target: WebhookTargetOptional,
@@ -53,10 +44,12 @@ export const updateWebhookHandler = async ({
   region?: string;
 }): Promise<IPromptResponse> => {
   if (target === undefined && triggers === undefined) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: 'At least one of target or triggers must be provided to update a webhook.',
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: 'At least one of target or triggers must be provided to update a webhook.',
+      }),
+    ).promptResponse;
   }
 
   const maybeService = getConversationService(TOOL_NAME);
@@ -75,17 +68,22 @@ export const updateWebhookHandler = async ({
       webhook_id: webhookId,
       webhookUpdateRequestBody,
     });
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      webhook: formatWebhook(response),
-      ...(triggers !== undefined && hasNoTriggers(triggers) && {
-        warning: buildDormantTriggersWarning(webhookId),
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        webhook: formatWebhook(response),
+        ...(triggers !== undefined &&
+          hasNoTriggers(triggers) && {
+            warning: buildDormantTriggersWarning(webhookId),
+          }),
       }),
-    })).promptResponse;
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: appendRegionHint(error, usedRegion),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: appendRegionHint(error, usedRegion),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/utils/app-tools-helper.ts
+++ b/src/tools/conversation/utils/app-tools-helper.ts
@@ -13,10 +13,7 @@ export const addChannelToApp = async (
 ): Promise<IPromptResponse> => {
   try {
     const existingApp = await conversationService.app.get({ app_id: appId });
-    const channelCredentials = mergeChannelCredentials(
-      existingApp.channel_credentials,
-      credential,
-    );
+    const channelCredentials = mergeChannelCredentials(existingApp.channel_credentials, credential);
 
     const response = await conversationService.app.update({
       app_id: appId,
@@ -25,14 +22,18 @@ export const addChannelToApp = async (
       },
     });
 
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      app: formatAppResponse(response),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        app: formatAppResponse(response),
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: appendRegionHint(error, usedRegion),
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: appendRegionHint(error, usedRegion),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/conversation/utils/build-channel-credential.ts
+++ b/src/tools/conversation/utils/build-channel-credential.ts
@@ -35,10 +35,10 @@ export const buildWhatsAppChannelCredential = (
 
 export const mergeChannelCredentials = (
   existing: Conversation.ConversationChannelCredentialResponse[] | undefined,
-  incoming: Conversation.ConversationChannelCredentialRequest
+  incoming: Conversation.ConversationChannelCredentialRequest,
 ): Conversation.ConversationChannelCredentialRequest[] => {
   const credentials = (existing ?? []).map(toChannelCredentialRequest);
-  const index = credentials.findIndex(cred => cred.channel === incoming.channel);
+  const index = credentials.findIndex((cred) => cred.channel === incoming.channel);
   if (index >= 0) {
     credentials[index] = incoming;
   } else {
@@ -47,19 +47,15 @@ export const mergeChannelCredentials = (
   return credentials;
 };
 
-const optionalRequestFields = (
-  credential: Conversation.ConversationChannelCredentialResponse
-) => ({
+const optionalRequestFields = (credential: Conversation.ConversationChannelCredentialResponse) => ({
   ...(credential.credential_ordinal_number !== undefined
     ? { credential_ordinal_number: credential.credential_ordinal_number }
     : {}),
-  ...(credential.callback_secret !== undefined
-    ? { callback_secret: credential.callback_secret }
-    : {}),
+  ...(credential.callback_secret !== undefined ? { callback_secret: credential.callback_secret } : {}),
 });
 
 export const toChannelCredentialRequest = (
-  credential: Conversation.ConversationChannelCredentialResponse
+  credential: Conversation.ConversationChannelCredentialResponse,
 ): Conversation.ConversationChannelCredentialRequest => {
   const optional = optionalRequestFields(credential);
 

--- a/src/tools/conversation/utils/conversation-service-helper.ts
+++ b/src/tools/conversation/utils/conversation-service-helper.ts
@@ -16,37 +16,26 @@ import { formatUserAgent } from '../../../utils';
 
 export const getConversationService = (toolName: string): ConversationService | PromptResponse => {
   const projectId = process.env.PROJECT_ID;
-  const keyId     = process.env.KEY_ID;
+  const keyId = process.env.KEY_ID;
   const keySecret = process.env.KEY_SECRET;
 
   if (!projectId || !keyId || !keySecret) {
-    return new PromptResponse(
-      'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.'
-    );
+    return new PromptResponse('Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.');
   }
 
-  const conversationService  = new ConversationService({});
+  const conversationService = new ConversationService({});
   const authenticationPlugin = new Oauth2TokenRequest(keyId, keySecret);
   const additionalHeadersPlugin = new AdditionalHeadersRequest({
-    headers: buildHeader(
-      'User-Agent',
-      formatUserAgent(toolName, projectId),
-    ),
+    headers: buildHeader('User-Agent', formatUserAgent(toolName, projectId)),
   });
 
   const fetcher = new ApiFetchClient({
     projectId,
-    requestPlugins: [
-      authenticationPlugin,
-      additionalHeadersPlugin,
-    ],
+    requestPlugins: [authenticationPlugin, additionalHeadersPlugin],
   });
   const templateFetcher = new ApiFetchClient({
     projectId,
-    requestPlugins: [
-      authenticationPlugin,
-      additionalHeadersPlugin,
-    ],
+    requestPlugins: [authenticationPlugin, additionalHeadersPlugin],
   });
 
   // Remove the VersionRequest plugin, as we override the user-agent header
@@ -54,41 +43,49 @@ export const getConversationService = (toolName: string): ConversationService | 
   templateFetcher.apiClientOptions.requestPlugins?.shift();
 
   // Replace the region placeholder with US by default
-  fetcher.apiClientOptions.hostname
-    = CONVERSATION_HOSTNAME.replace(REGION_PATTERN, `${ConversationRegion.UNITED_STATES}.`);
-  templateFetcher.apiClientOptions.hostname
-    = CONVERSATION_TEMPLATES_HOSTNAME.replace(REGION_PATTERN, `${ConversationRegion.UNITED_STATES}.`);
+  fetcher.apiClientOptions.hostname = CONVERSATION_HOSTNAME.replace(
+    REGION_PATTERN,
+    `${ConversationRegion.UNITED_STATES}.`,
+  );
+  templateFetcher.apiClientOptions.hostname = CONVERSATION_TEMPLATES_HOSTNAME.replace(
+    REGION_PATTERN,
+    `${ConversationRegion.UNITED_STATES}.`,
+  );
 
   conversationService.lazyConversationClient.apiFetchClient = fetcher;
   conversationService.lazyConversationTemplateClient.apiFetchClient = templateFetcher;
 
   return conversationService;
-}
+};
 
 export const getConversationAppId = (appId: string | undefined): string | PromptResponse => {
   if (!appId) {
     appId = process.env.CONVERSATION_APP_ID;
     if (!appId) {
-      return new PromptResponse('The "CONVERSATION_APP_ID" is not set in the environment variables and the "appId" property is not provided.');
+      return new PromptResponse(
+        'The "CONVERSATION_APP_ID" is not set in the environment variables and the "appId" property is not provided.',
+      );
     }
   }
   return appId;
-}
+};
 
 export const setConversationRegion = (promptRegion: string | undefined, conversationService: ConversationService) => {
   const region = promptRegion ?? process.env.CONVERSATION_REGION ?? ConversationRegion.UNITED_STATES;
   conversationService.lazyConversationClient.sharedConfig.conversationRegion = region;
   const formattedRegion = region !== '' ? `${region}.` : '';
-  conversationService.lazyConversationClient.apiFetchClient!.apiClientOptions.hostname
-    = formatRegionalizedHostname(CONVERSATION_HOSTNAME, formattedRegion);
+  conversationService.lazyConversationClient.apiFetchClient!.apiClientOptions.hostname = formatRegionalizedHostname(
+    CONVERSATION_HOSTNAME,
+    formattedRegion,
+  );
   return region;
-}
+};
 
 export const setTemplateRegion = (promptRegion: string | undefined, conversationService: ConversationService) => {
   const region = promptRegion ?? process.env.CONVERSATION_REGION ?? ConversationRegion.UNITED_STATES;
   conversationService.lazyConversationTemplateClient.sharedConfig.conversationRegion = region;
   const formattedRegion = region !== '' ? `${region}.` : '';
-  conversationService.lazyConversationTemplateClient.apiFetchClient!.apiClientOptions.hostname
-    = formatRegionalizedHostname(CONVERSATION_TEMPLATES_HOSTNAME, formattedRegion);
+  conversationService.lazyConversationTemplateClient.apiFetchClient!.apiClientOptions.hostname =
+    formatRegionalizedHostname(CONVERSATION_TEMPLATES_HOSTNAME, formattedRegion);
   return region;
-}
+};

--- a/src/tools/conversation/utils/conversation-tools-helper.ts
+++ b/src/tools/conversation/utils/conversation-tools-helper.ts
@@ -2,7 +2,7 @@ import { ToolsConfig } from '../../../types';
 
 const defineToolsConfig = <T extends Record<string, ToolsConfig>>(config: T) => {
   return config;
-}
+};
 
 export const toolsConfig = defineToolsConfig({
   listConversationApps: {

--- a/src/tools/conversation/utils/format-app-response.ts
+++ b/src/tools/conversation/utils/format-app-response.ts
@@ -8,12 +8,10 @@ export const formatAppResponse = (app: Conversation.AppResponse | undefined) => 
     id: app.id,
     display_name: app.display_name,
     processing_mode: app.processing_mode,
-    channel_credentials: app.channel_credentials?.map(cred => ({
+    channel_credentials: app.channel_credentials?.map((cred) => ({
       channel: cred.channel,
       status: cred.state?.status,
-      ...(cred.channel_known_id !== undefined
-        ? { channel_known_id: cred.channel_known_id }
-        : {}),
+      ...(cred.channel_known_id !== undefined ? { channel_known_id: cred.channel_known_id } : {}),
       ...('static_bearer' in cred && cred.static_bearer?.claimed_identity !== undefined
         ? { claimed_identity: cred.static_bearer.claimed_identity }
         : {}),

--- a/src/tools/conversation/utils/format-list-all-apps-response.ts
+++ b/src/tools/conversation/utils/format-list-all-apps-response.ts
@@ -5,14 +5,14 @@ export const formatListAllAppsResponse = (response: Conversation.ListAppsRespons
     return { apps: [] };
   }
   return {
-    apps: response.apps?.map(app => ({
+    apps: response.apps?.map((app) => ({
       id: app.id,
       display_name: app.display_name,
       channel_credentials: app.channel_credentials
-        ?.filter(cred => cred.state?.status === 'ACTIVE')
-        .map(cred => ({
-        channel: cred.channel
-      }))
-    }))
+        ?.filter((cred) => cred.state?.status === 'ACTIVE')
+        .map((cred) => ({
+          channel: cred.channel,
+        })),
+    })),
   };
 };

--- a/src/tools/conversation/utils/format-list-all-templates-response.ts
+++ b/src/tools/conversation/utils/format-list-all-templates-response.ts
@@ -1,7 +1,7 @@
 import { Conversation } from '@sinch/conversation';
 
 export const formatListAllTemplatesResponse = (
-  data: Conversation.V2ListTemplatesResponse
+  data: Conversation.V2ListTemplatesResponse,
 ): {
   id: string;
   description?: string;
@@ -14,8 +14,6 @@ export const formatListAllTemplatesResponse = (
     description: template.description,
     version: template.version,
     defaultTranslation: template.default_translation,
-    translations: template.translations?.map(
-      (t) => `${t.language_code} (version "${t.version}")`
-    ),
+    translations: template.translations?.map((t) => `${t.language_code} (version "${t.version}")`),
   }));
 };

--- a/src/tools/conversation/utils/format-webhook-response.ts
+++ b/src/tools/conversation/utils/format-webhook-response.ts
@@ -8,9 +8,7 @@ export const formatWebhook = (webhook: Conversation.Webhook) => ({
   triggers: webhook.triggers,
 });
 
-export const formatListWebhooksResponse = (
-  response: Conversation.ListWebhooksResponse | undefined,
-) => {
+export const formatListWebhooksResponse = (response: Conversation.ListWebhooksResponse | undefined) => {
   if (!response?.webhooks?.length) {
     return { webhooks: [] };
   }

--- a/src/tools/conversation/utils/geocoding.ts
+++ b/src/tools/conversation/utils/geocoding.ts
@@ -10,17 +10,17 @@ export const getLatitudeLongitudeFromAddress = async (address: string): Promise<
   const fallbackCoordinates: GeocodingAddress = {
     latitude: 0,
     longitude: 0,
-    formattedAddress: 'Unknown'
+    formattedAddress: 'Unknown',
   };
   try {
     const url = 'https://maps.googleapis.com/maps/api/geocode/json';
     const queryParams = {
       address,
-      key: process.env.GEOCODING_API_KEY
+      key: process.env.GEOCODING_API_KEY,
     };
 
     const response = await axios.get(url, {
-      params: queryParams
+      params: queryParams,
     });
     const data = response.data;
 
@@ -29,7 +29,7 @@ export const getLatitudeLongitudeFromAddress = async (address: string): Promise<
       return {
         latitude: location.lat,
         longitude: location.lng,
-        formattedAddress: data.results[0].formatted_address
+        formattedAddress: data.results[0].formatted_address,
       };
     } else {
       console.error('Geocoding failed:', data.status);

--- a/src/tools/conversation/utils/send-message-builder.ts
+++ b/src/tools/conversation/utils/send-message-builder.ts
@@ -5,17 +5,16 @@ export const buildMessageBase = async (
   appId: string,
   recipient: string,
   channel: string[],
-  sender?: string
+  sender?: string,
 ): Promise<Omit<Conversation.SendMessageRequest<Conversation.IdentifiedBy>, 'message'>> => {
-
   const messageBase: Omit<Conversation.SendMessageRequest<Conversation.IdentifiedBy>, 'message' | 'recipient'> = {
     app_id: appId,
-    processing_strategy: 'DISPATCH_ONLY'
+    processing_strategy: 'DISPATCH_ONLY',
   };
 
   const channel_identities: Conversation.ChannelRecipientIdentity[] = [];
   const appConfiguration = await conversationService.app.get({ app_id: appId });
-  const configuredChannels: string[] = appConfiguration.channel_credentials?.map(channel => channel.channel) || [];
+  const configuredChannels: string[] = appConfiguration.channel_credentials?.map((channel) => channel.channel) || [];
   for (let c of channel) {
     if (c === 'MMS' && !configuredChannels.includes('MMS')) {
       // Fallback to SMS if MMS is not configured
@@ -23,18 +22,18 @@ export const buildMessageBase = async (
     }
     channel_identities.push({
       channel: c as Conversation.ConversationChannel,
-      identity: recipient
+      identity: recipient,
     });
   }
 
   addSMSFallback(appConfiguration, channel, recipient, channel_identities);
 
-  if(!sender) {
+  if (!sender) {
     sender = process.env.DEFAULT_SMS_ORIGINATOR;
   }
   if (sender) {
     messageBase.channel_properties = {
-      'SMS_SENDER': sender
+      SMS_SENDER: sender,
     };
   }
 
@@ -42,11 +41,10 @@ export const buildMessageBase = async (
     ...messageBase,
     recipient: {
       identified_by: {
-        channel_identities
-      }
-    }
+        channel_identities,
+      },
+    },
   };
-
 };
 
 // This function adds an SMS fallback for RCS or WHATSAPP if the channel is RCS or WHATSAPP and SMS is not already included in the channel_identities
@@ -54,14 +52,14 @@ const addSMSFallback = (
   appConfiguration: Conversation.AppResponse,
   channels: string[],
   recipient: string,
-  channel_identities: Conversation.ChannelRecipientIdentity[]
+  channel_identities: Conversation.ChannelRecipientIdentity[],
 ) => {
   if (channels.includes('RCS') || channels.includes('WHATSAPP')) {
-    const smsChannel = channels.find(c => c === 'SMS');
+    const smsChannel = channels.find((c) => c === 'SMS');
     if (!smsChannel && isSMSChannelConfigured(appConfiguration)) {
       channel_identities.push({
         channel: 'SMS',
-        identity: recipient
+        identity: recipient,
       });
     }
   }
@@ -69,7 +67,7 @@ const addSMSFallback = (
 
 const isSMSChannelConfigured = (appConfiguration: Conversation.AppResponse): boolean => {
   if (appConfiguration.channel_credentials) {
-    const smsChannel = appConfiguration.channel_credentials.find(channel => channel.channel === 'SMS');
+    const smsChannel = appConfiguration.channel_credentials.find((channel) => channel.channel === 'SMS');
     return !!smsChannel;
   }
   return false;

--- a/src/tools/conversation/utils/webhook-tools-helper.ts
+++ b/src/tools/conversation/utils/webhook-tools-helper.ts
@@ -3,14 +3,11 @@ import { SupportedConversationRegion } from '@sinch/sdk-client';
 export const appendRegionHint = (error: unknown, region: string): string => {
   const message = error instanceof Error ? error.message : String(error);
   const otherRegions = Object.values(SupportedConversationRegion).filter((r) => r !== region);
-  const regionsHint = otherRegions.length > 0
-    ? ` Other regions to try: ${otherRegions.join(', ')}.`
-    : '';
+  const regionsHint = otherRegions.length > 0 ? ` Other regions to try: ${otherRegions.join(', ')}.` : '';
   return `${message}. If the resource cannot be found, the region parameter may be incorrect. Current region: ${region}.${regionsHint}`;
 };
 
 export const buildDormantTriggersWarning = (webhookId: string): string =>
   `This webhook has no triggers and will remain dormant. Use update-webhook with webhookId="${webhookId}" and triggers=[...] to activate it.`;
 
-export const hasNoTriggers = (triggers: string[] | undefined): boolean =>
-  !triggers || triggers.length === 0;
+export const hasNoTriggers = (triggers: string[] | undefined): boolean => !triggers || triggers.length === 0;

--- a/src/tools/email/analytics-metrics.ts
+++ b/src/tools/email/analytics-metrics.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { IPromptResponse, PromptResponse, Tags } from '../../types';
-import { getMailgunApiKey} from './utils/mailgun-service-helper';
+import { getMailgunApiKey } from './utils/mailgun-service-helper';
 import { EmailToolKey, getToolName, sha256, toolsConfig } from './utils/mailgun-tools-helper';
 import { formatUserAgent, matchesAnyTag } from '../../utils';
 
@@ -55,17 +55,32 @@ const metricsTypes = [
   'temporary_fail_rate',
   'unique_clicked_rate',
   'unique_opened_rate',
-  'unsubscribed_rate'
+  'unsubscribed_rate',
 ] as const;
 
 type MetricsType = (typeof metricsTypes)[number];
 
 const AnalyticsMetricsSchema = {
   domain: z.string().optional().describe('(Optional) The Mailgun domain to fetch metrics for.'),
-  metrics: z.array(z.enum(metricsTypes)).optional().describe('(Optional) The specific metrics to receive the stats for. If not provided, all metrics will be returned.'),
-  beginSearchPeriod: z.string().optional().describe('(Optional) The beginning of the search time range in RFC-2822 format (e.g., Mon, 02 Jun 2025 00:00:00 +0100).'),
-  endSearchPeriod: z.string().optional().describe('(Optional) The end of the search time range in RFC-2822 format (e.g., Mon, 09 Jun 2025 00:00:00 +0100).'),
-}
+  metrics: z
+    .array(z.enum(metricsTypes))
+    .optional()
+    .describe(
+      '(Optional) The specific metrics to receive the stats for. If not provided, all metrics will be returned.',
+    ),
+  beginSearchPeriod: z
+    .string()
+    .optional()
+    .describe(
+      '(Optional) The beginning of the search time range in RFC-2822 format (e.g., Mon, 02 Jun 2025 00:00:00 +0100).',
+    ),
+  endSearchPeriod: z
+    .string()
+    .optional()
+    .describe(
+      '(Optional) The end of the search time range in RFC-2822 format (e.g., Mon, 09 Jun 2025 00:00:00 +0100).',
+    ),
+};
 
 type AnalyticsMetrics = z.infer<z.ZodObject<typeof AnalyticsMetricsSchema>>;
 
@@ -73,15 +88,18 @@ const TOOL_KEY: EmailToolKey = 'analyticsMetrics';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerAnalyticsMetrics = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Get email analytics metrics from Mailgun for an account. All parameters are optional. You can filter by domain, metrics type and specify a time range. By default, it will return all metrics for all your domains for the last 7 days.',
+      description:
+        'Get email analytics metrics from Mailgun for an account. All parameters are optional. You can filter by domain, metrics type and specify a time range. By default, it will return all metrics for all your domains for the last 7 days.',
       inputSchema: AnalyticsMetricsSchema,
     },
-    analyticsMetricsHandler
+    analyticsMetricsHandler,
   );
 };
 
@@ -89,7 +107,7 @@ export const analyticsMetricsHandler = async ({
   domain,
   metrics,
   beginSearchPeriod,
-  endSearchPeriod
+  endSearchPeriod,
 }: AnalyticsMetrics): Promise<IPromptResponse> => {
   const maybeApiKey = getMailgunApiKey();
   if (typeof maybeApiKey !== 'string') {
@@ -98,27 +116,33 @@ export const analyticsMetricsHandler = async ({
   const mailgunApiKey = maybeApiKey;
 
   const body: Record<string, any> = {};
-  if (domain) body.domain = {
-    AND: [
-      {
-        attribute: 'domain',
-        comparator: '=',
-        values: [
-          {
-            label: domain,
-            value: domain
-          }
-        ]
-      }
-    ]
-  };
+  if (domain) {
+    body.domain = {
+      AND: [
+        {
+          attribute: 'domain',
+          comparator: '=',
+          values: [
+            {
+              label: domain,
+              value: domain,
+            },
+          ],
+        },
+      ],
+    };
+  }
   if (metrics && metrics.length > 0) {
     body.metrics = metrics;
   } else {
     body.metrics = metricsTypes;
   }
-  if (beginSearchPeriod) body.begin = beginSearchPeriod;
-  if (endSearchPeriod) body.end = endSearchPeriod;
+  if (beginSearchPeriod) {
+    body.begin = beginSearchPeriod;
+  }
+  if (endSearchPeriod) {
+    body.end = endSearchPeriod;
+  }
   body.include_aggregates = true;
 
   const url = `https://api.mailgun.net/v1/analytics/metrics`;
@@ -126,44 +150,50 @@ export const analyticsMetricsHandler = async ({
   const response = await fetch(url, {
     method: 'POST',
     headers: {
-      'Authorization': 'Basic ' + Buffer.from(`api:${mailgunApiKey}`).toString('base64'),
+      Authorization: 'Basic ' + Buffer.from(`api:${mailgunApiKey}`).toString('base64'),
       'Content-Type': 'application/json',
       'User-Agent': formatUserAgent(TOOL_NAME, sha256(mailgunApiKey)),
     },
-    body: JSON.stringify(body)
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: `Mailgun API error: ${response.status} ${response.statusText}`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: `Mailgun API error: ${response.status} ${response.statusText}`,
+      }),
+    ).promptResponse;
   }
 
   let responseData;
   try {
-    responseData = await response.json() as MailgunAnalyticsMetricsResponse;
+    responseData = (await response.json()) as MailgunAnalyticsMetricsResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 
-  return new PromptResponse(JSON.stringify({
-    success: true,
-    metrics: responseData.aggregates.metrics,
-    period: {
-      begin: responseData.start,
-      end: responseData.end
-    }
-  })).promptResponse;
-}
+  return new PromptResponse(
+    JSON.stringify({
+      success: true,
+      metrics: responseData.aggregates.metrics,
+      period: {
+        begin: responseData.start,
+        end: responseData.end,
+      },
+    }),
+  ).promptResponse;
+};
 
 interface MailgunAnalyticsMetricsResponse {
   start: string;
   end: string;
   aggregates: {
     metrics: Record<MetricsType, number>;
-  }
+  };
 }

--- a/src/tools/email/list-email-events.ts
+++ b/src/tools/email/list-email-events.ts
@@ -6,8 +6,15 @@ import { getMailgunCredentials } from './utils/mailgun-service-helper';
 import { EmailToolKey, getToolName, sha256, toolsConfig } from './utils/mailgun-tools-helper';
 
 const eventTypes = [
-  'accepted', 'rejected', 'delivered', 'failed',
-  'opened', 'clicked', 'unsubscribed', 'complained', 'stored'
+  'accepted',
+  'rejected',
+  'delivered',
+  'failed',
+  'opened',
+  'clicked',
+  'unsubscribed',
+  'complained',
+  'stored',
 ] as const;
 
 type EventType = (typeof eventTypes)[number];
@@ -16,8 +23,16 @@ const ListEmailEventsSchema = {
   domain: z.string().optional().describe('(Optional) The Mailgun domain to fetch events for.'),
   event: z.enum(eventTypes).optional().describe('(Optional) Filter by event type (e.g., delivered, opened, failed).'),
   limit: z.number().int().min(1).max(300).optional().describe('(Optional) Number of events to return (max: 300).'),
-  beginSearchPeriod: z.string().datetime().optional().describe('(Optional) The beginning of the search time range in ISO 8601 format (e.g., 2025-01-01T00:00:00Z).'),
-  endSearchPeriod: z.string().datetime().optional().describe('(Optional) The end of the search time range in ISO 8601 format (e.g., 2025-01-01T00:00:00Z).'),
+  beginSearchPeriod: z
+    .string()
+    .datetime()
+    .optional()
+    .describe('(Optional) The beginning of the search time range in ISO 8601 format (e.g., 2025-01-01T00:00:00Z).'),
+  endSearchPeriod: z
+    .string()
+    .datetime()
+    .optional()
+    .describe('(Optional) The end of the search time range in ISO 8601 format (e.g., 2025-01-01T00:00:00Z).'),
 };
 
 type ListEmailEvents = z.infer<z.ZodObject<typeof ListEmailEventsSchema>>;
@@ -26,15 +41,18 @@ const TOOL_KEY: EmailToolKey = 'listEmailEvents';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListEmailEvents = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Get a list of email events from Mailgun for a specific domain. You can filter by event type and limit the number of results.',
+      description:
+        'Get a list of email events from Mailgun for a specific domain. You can filter by event type and limit the number of results.',
       inputSchema: ListEmailEventsSchema,
     },
-    listEmailEventsHandler
+    listEmailEventsHandler,
   );
 };
 
@@ -43,7 +61,7 @@ export const listEmailEventsHandler = async ({
   event,
   limit,
   beginSearchPeriod,
-  endSearchPeriod
+  endSearchPeriod,
 }: ListEmailEvents): Promise<IPromptResponse> => {
   const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
@@ -52,10 +70,18 @@ export const listEmailEventsHandler = async ({
   const credentials = maybeCredentials;
 
   const params = new URLSearchParams();
-  if (event) params.append('event', event);
-  if (limit) params.append('limit', limit.toString());
-  if (beginSearchPeriod) params.append('begin', (new Date(beginSearchPeriod).getTime() / 1000).toString());
-  if (endSearchPeriod) params.append('end', (new Date(endSearchPeriod).getTime() / 1000).toString());
+  if (event) {
+    params.append('event', event);
+  }
+  if (limit) {
+    params.append('limit', limit.toString());
+  }
+  if (beginSearchPeriod) {
+    params.append('begin', (new Date(beginSearchPeriod).getTime() / 1000).toString());
+  }
+  if (endSearchPeriod) {
+    params.append('end', (new Date(endSearchPeriod).getTime() / 1000).toString());
+  }
   if (beginSearchPeriod && !endSearchPeriod) {
     params.append('end', (new Date().getTime() / 1000).toString()); // Default to now if no end is provided
   }
@@ -64,29 +90,36 @@ export const listEmailEventsHandler = async ({
 
   const response = await fetch(url, {
     headers: {
-      'Authorization': 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
+      Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
       'User-Agent': formatUserAgent(TOOL_NAME, sha256(credentials.apiKey)),
-    }
+    },
   });
 
   if (!response.ok) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: `Mailgun API error: ${response.status} ${response.statusText}`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: `Mailgun API error: ${response.status} ${response.statusText}`,
+      }),
+    ).promptResponse;
   }
 
   let responseData;
   try {
-    responseData = await response.json() as MailgunEventsResponse;
+    responseData = (await response.json()) as MailgunEventsResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 
-  const grouped: Map<string, { recipient?: string; subject?: string; from?: string; events: { event: string; timestamp: string }[] }> = new Map();
+  const grouped: Map<
+    string,
+    { recipient?: string; subject?: string; from?: string; events: { event: string; timestamp: string }[] }
+  > = new Map();
 
   const events = responseData.items || [];
   for (const e of events) {
@@ -101,17 +134,23 @@ export const listEmailEventsHandler = async ({
         recipient,
         subject,
         from,
-        events: []
+        events: [],
       });
     }
     const group = grouped.get(messageId)!;
-    if (subject && !group.subject) group.subject = subject;
-    if (from && !group.from) group.from = from;
-    if (recipient && !group.recipient) group.recipient = recipient;
+    if (subject && !group.subject) {
+      group.subject = subject;
+    }
+    if (from && !group.from) {
+      group.from = from;
+    }
+    if (recipient && !group.recipient) {
+      group.recipient = recipient;
+    }
 
     group.events.push({
       event: e.event || '',
-      timestamp: e.timestamp ? new Date(e.timestamp * 1000).toISOString() : ''
+      timestamp: e.timestamp ? new Date(e.timestamp * 1000).toISOString() : '',
     });
   }
 
@@ -120,13 +159,15 @@ export const listEmailEventsHandler = async ({
     from: data.from,
     to: data.recipient,
     subject: data.subject,
-    events: data.events
+    events: data.events,
   }));
 
-  return new PromptResponse(JSON.stringify({
-    events: groupedArray,
-    total_count: events.length
-  })).promptResponse;
+  return new PromptResponse(
+    JSON.stringify({
+      events: groupedArray,
+      total_count: events.length,
+    }),
+  ).promptResponse;
 };
 
 interface MailgunEventsResponse {

--- a/src/tools/email/list-email-templates.ts
+++ b/src/tools/email/list-email-templates.ts
@@ -6,7 +6,12 @@ import { EmailToolKey, getToolName, sha256, toolsConfig } from './utils/mailgun-
 import { formatUserAgent, isPromptResponse, matchesAnyTag } from '../../utils';
 
 const ListEmailTemplatesSchema = {
-  domain: z.string().optional().describe('The domain to use for sending the email. It would override the domain provided in the environment variables.'),
+  domain: z
+    .string()
+    .optional()
+    .describe(
+      'The domain to use for sending the email. It would override the domain provided in the environment variables.',
+    ),
 };
 
 type ListEmailTemplates = z.infer<z.ZodObject<typeof ListEmailTemplatesSchema>>;
@@ -15,21 +20,22 @@ const TOOL_KEY: EmailToolKey = 'listEmailTemplates';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListEmailTemplates = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Get a list of Email templates from Mailgun for a specific domain. Note that the Messaging templates (omni-channel or channel-specific such as WhatsApp) are NOT included in this list - they can be found with another tool: list-messaging-templates. Do not try to use this tool to list Messaging templates, it will not work.',
+      description:
+        'Get a list of Email templates from Mailgun for a specific domain. Note that the Messaging templates (omni-channel or channel-specific such as WhatsApp) are NOT included in this list - they can be found with another tool: list-messaging-templates. Do not try to use this tool to list Messaging templates, it will not work.',
       inputSchema: ListEmailTemplatesSchema,
     },
-    listEmailTemplatesHandler
+    listEmailTemplatesHandler,
   );
 };
 
-export const listEmailTemplatesHandler = async ({
-  domain
-}: ListEmailTemplates): Promise<IPromptResponse> => {
+export const listEmailTemplatesHandler = async ({ domain }: ListEmailTemplates): Promise<IPromptResponse> => {
   const maybeCredentials = await getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;
@@ -40,38 +46,44 @@ export const listEmailTemplatesHandler = async ({
 
   const response = await fetch(url, {
     headers: {
-      'Authorization': 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
+      Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
       'User-Agent': formatUserAgent(TOOL_NAME, sha256(credentials.apiKey)),
-    }
+    },
   });
 
   if (!response.ok) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: `Mailgun API error: ${response.status} ${response.statusText}`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: `Mailgun API error: ${response.status} ${response.statusText}`,
+      }),
+    ).promptResponse;
   }
 
   let responseData;
   try {
-    responseData = await response.json() as MailgunTemplatesResponse;
+    responseData = (await response.json()) as MailgunTemplatesResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 
-  return new PromptResponse(JSON.stringify({
-    templates: responseData.items.map(template => ({
-      id: template.id,
-      name: template.name,
-      description: template.description || null,
-      createdAt: template.createdAt ? new Date(template.createdAt).toISOString() : null
-    })),
-    total_count: responseData.items.length
-  })).promptResponse;
-}
+  return new PromptResponse(
+    JSON.stringify({
+      templates: responseData.items.map((template) => ({
+        id: template.id,
+        name: template.name,
+        description: template.description || null,
+        createdAt: template.createdAt ? new Date(template.createdAt).toISOString() : null,
+      })),
+      total_count: responseData.items.length,
+    }),
+  ).promptResponse;
+};
 
 interface MailgunTemplatesResponse {
   items: MailgunTemplate[];

--- a/src/tools/email/retrieve-email-info.ts
+++ b/src/tools/email/retrieve-email-info.ts
@@ -20,7 +20,12 @@ interface Event {
 
 const RetrieveEmailInfoSchema = {
   emailId: z.string().describe('The email ID.'),
-  domain: z.string().optional().describe('The domain to use for retrieving the email. If defined, it will override the domain provided in the environment variable "MAILGUN_DOMAIN".'),
+  domain: z
+    .string()
+    .optional()
+    .describe(
+      'The domain to use for retrieving the email. If defined, it will override the domain provided in the environment variable "MAILGUN_DOMAIN".',
+    ),
 };
 
 type RetrieveEmailInfo = z.infer<z.ZodObject<typeof RetrieveEmailInfoSchema>>;
@@ -29,7 +34,9 @@ const TOOL_KEY: EmailToolKey = 'retrieveEmailInfo';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerRetrieveEmailInfo = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -37,39 +44,35 @@ export const registerRetrieveEmailInfo = (server: McpServer, tags: Tags[]) => {
       description: 'Retrieve the content of an email and the events that happened thanks to its ID',
       inputSchema: RetrieveEmailInfoSchema,
     },
-    retrieveEmailInfoHandler
+    retrieveEmailInfoHandler,
   );
 };
 
-export const retrieveEmailInfoHandler = async({
-  emailId,
-  domain
-}: RetrieveEmailInfo): Promise<IPromptResponse> => {
+export const retrieveEmailInfoHandler = async ({ emailId, domain }: RetrieveEmailInfo): Promise<IPromptResponse> => {
   const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;
   }
   const credentials = maybeCredentials;
 
-  const resp = await fetch(
-    `https://api.mailgun.net/v3/${credentials.domain}/events?message-id=${emailId}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
-        'User-Agent': formatUserAgent(TOOL_NAME, sha256(credentials.apiKey)),
-      }
-    }
-  );
+  const resp = await fetch(`https://api.mailgun.net/v3/${credentials.domain}/events?message-id=${emailId}`, {
+    method: 'GET',
+    headers: {
+      Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
+      'User-Agent': formatUserAgent(TOOL_NAME, sha256(credentials.apiKey)),
+    },
+  });
 
   if (resp.status !== 200) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: `An error occurred when trying to retrieve the events related to the email ID ${emailId}. The status code is ${resp.status}.`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: `An error occurred when trying to retrieve the events related to the email ID ${emailId}. The status code is ${resp.status}.`,
+      }),
+    ).promptResponse;
   }
 
-  const data = await resp.json() as EventList;
+  const data = (await resp.json()) as EventList;
   let storageUrl;
   const events = [];
   for (const event of data.items) {
@@ -79,7 +82,7 @@ export const retrieveEmailInfoHandler = async({
     }
     events.push({
       event: eventType,
-      timestamp: new Date(event.timestamp * 1000).toISOString()
+      timestamp: new Date(event.timestamp * 1000).toISOString(),
     });
   }
 
@@ -93,33 +96,38 @@ export const retrieveEmailInfoHandler = async({
     events: Array<{ event?: string; timestamp: string }>;
   } = {
     message_id: emailId,
-    events: events
+    events: events,
   };
 
-  const storedEmail = await fetch(
-    storageUrl!,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
-        'User-Agent': formatUserAgent(TOOL_NAME, sha256(credentials.apiKey)),
-      }
-    }
-  );
+  const storedEmail = await fetch(storageUrl!, {
+    method: 'GET',
+    headers: {
+      Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
+      'User-Agent': formatUserAgent(TOOL_NAME, sha256(credentials.apiKey)),
+    },
+  });
 
   if (storedEmail.status === 200) {
-    const storedEmailData = await storedEmail.json() as { 'body-html': string; Sender: string; From: string; To: string; Subject: string };
+    const storedEmailData = (await storedEmail.json()) as {
+      'body-html': string;
+      Sender: string;
+      From: string;
+      To: string;
+      Subject: string;
+    };
     result.sender = storedEmailData['Sender'];
     result.from = storedEmailData['From'];
     result.to = storedEmailData['To'];
     result.subject = storedEmailData['Subject'];
     result.body_html = storedEmailData['body-html'];
   } else {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: `An error occurred when trying to retrieve the events related to the email ID ${emailId}. The status code is ${storedEmail.status}.`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: `An error occurred when trying to retrieve the events related to the email ID ${emailId}. The status code is ${storedEmail.status}.`,
+      }),
+    ).promptResponse;
   }
 
   return new PromptResponse(JSON.stringify({ success: true, data: result })).promptResponse;
-}
+};

--- a/src/tools/email/send-email.ts
+++ b/src/tools/email/send-email.ts
@@ -11,9 +11,17 @@ const SendEmailSchema = {
   subject: z.string().describe('The subject of the email.'),
   sender: z.string().optional().describe('The sender of the email.'),
   body: z.string().optional().describe('The body of the email. Can be text or HTML'),
-  template: z.string().optional().describe('The name of a template to use to render the email body. If provided, the body will be ignored.'),
+  template: z
+    .string()
+    .optional()
+    .describe('The name of a template to use to render the email body. If provided, the body will be ignored.'),
   templateVariables: z.record(z.string()).optional().describe('Variables to use in the template.'),
-  domain: z.string().optional().describe('The domain to use for sending the email. It would override the domain provided in the environment variables.'),
+  domain: z
+    .string()
+    .optional()
+    .describe(
+      'The domain to use for sending the email. It would override the domain provided in the environment variables.',
+    ),
 };
 
 type SendEmail = z.infer<z.ZodObject<typeof SendEmailSchema>>;
@@ -22,7 +30,9 @@ const TOOL_KEY: EmailToolKey = 'sendEmail';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSendEmail = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -30,7 +40,7 @@ export const registerSendEmail = (server: McpServer, tags: Tags[]) => {
       description: 'Send an email to a recipient with a subject and body.',
       inputSchema: SendEmailSchema,
     },
-    sendEmailHandler
+    sendEmailHandler,
   );
 };
 
@@ -41,7 +51,7 @@ export const sendEmailHandler = async ({
   body,
   template,
   templateVariables,
-  domain
+  domain,
 }: SendEmail): Promise<IPromptResponse> => {
   const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
@@ -52,10 +62,12 @@ export const sendEmailHandler = async ({
   if (!sender) {
     sender = process.env.MAILGUN_SENDER_ADDRESS;
     if (!sender) {
-      return new PromptResponse(JSON.stringify({
-        success: false,
-        error: 'The "sender" is not provided and MAILGUN_SENDER_ADDRESS is no set in the environment variables.'
-      })).promptResponse;
+      return new PromptResponse(
+        JSON.stringify({
+          success: false,
+          error: 'The "sender" is not provided and MAILGUN_SENDER_ADDRESS is no set in the environment variables.',
+        }),
+      ).promptResponse;
     }
   }
 
@@ -71,37 +83,40 @@ export const sendEmailHandler = async ({
   } else if (body) {
     form.set('html', body);
   } else {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: 'The "body" is not provided and no template name is specified.'
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: 'The "body" is not provided and no template name is specified.',
+      }),
+    ).promptResponse;
   }
 
-  const resp = await fetch(
-    `https://api.mailgun.net/v3/${credentials.domain}/messages`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
-        'User-Agent': formatUserAgent(TOOL_NAME, sha256(credentials.apiKey)),
-      },
-      body: form
-    }
-  );
+  const resp = await fetch(`https://api.mailgun.net/v3/${credentials.domain}/messages`, {
+    method: 'POST',
+    headers: {
+      Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),
+      'User-Agent': formatUserAgent(TOOL_NAME, sha256(credentials.apiKey)),
+    },
+    body: form,
+  });
 
   if (resp.status !== 200) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: `(${resp.status} - ${resp.statusText}) An error occurred when sending an email to ${recipient}: ${await resp.text()}`
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: `(${resp.status} - ${resp.statusText}) An error occurred when sending an email to ${recipient}: ${await resp.text()}`,
+      }),
+    ).promptResponse;
   }
 
-  const data = await resp.json() as { id: string };
+  const data = (await resp.json()) as { id: string };
 
-  return new PromptResponse(JSON.stringify({
-    success: true,
-    message_id: data.id,
-    recipient: recipient,
-    subject: subject
-  })).promptResponse;
+  return new PromptResponse(
+    JSON.stringify({
+      success: true,
+      message_id: data.id,
+      recipient: recipient,
+      subject: subject,
+    }),
+  ).promptResponse;
 };

--- a/src/tools/email/utils/mailgun-service-helper.ts
+++ b/src/tools/email/utils/mailgun-service-helper.ts
@@ -3,11 +3,10 @@ import { PromptResponse } from '../../../types';
 export type MailgunCredentials = {
   domain: string;
   apiKey: string;
-}
+};
 
 // TODO: Replace this method with a getMailgunService() method that will return the SinchClient once the Mailgun service is implemented.
 export const getMailgunCredentials = (domain: string | undefined): MailgunCredentials | PromptResponse => {
-
   let credentials: MailgunCredentials | undefined = undefined;
 
   const mailgunDomain = domain || process.env.MAILGUN_DOMAIN;
@@ -16,7 +15,7 @@ export const getMailgunCredentials = (domain: string | undefined): MailgunCreden
   if (mailgunDomain && apiKey) {
     credentials = {
       domain: mailgunDomain,
-      apiKey: apiKey
+      apiKey: apiKey,
     };
   }
 
@@ -26,24 +25,27 @@ export const getMailgunCredentials = (domain: string | undefined): MailgunCreden
       errorMessage = 'The "domain" is not provided and "MAILGUN_DOMAIN" is not set in the environment variables.';
     }
     if (!apiKey) {
-      errorMessage += '"MAILGUN_API_KEY" is not set in the environment variables. The property is required to use the emails related tools.';
+      errorMessage +=
+        '"MAILGUN_API_KEY" is not set in the environment variables. The property is required to use the emails related tools.';
     }
     return new PromptResponse(errorMessage);
   }
 
   return credentials;
-
 };
 
 export const getMailgunApiKey = (): string | PromptResponse => {
   const apiKey = process.env.MAILGUN_API_KEY;
 
   if (!apiKey) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: 'The "MAILGUN_API_KEY" environment variable is not set. The property is required to use the emails related tools.'
-    }));
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error:
+          'The "MAILGUN_API_KEY" environment variable is not set. The property is required to use the emails related tools.',
+      }),
+    );
   }
 
   return apiKey;
-}
+};

--- a/src/tools/email/utils/mailgun-tools-helper.ts
+++ b/src/tools/email/utils/mailgun-tools-helper.ts
@@ -5,8 +5,8 @@ export const toolsConfig: Record<string, ToolsConfig> = {
   analyticsMetrics: {
     name: 'analytics-metrics',
     tags: ['all', 'email', 'analytics-metrics'],
-  } ,
-  listEmailEvents:{
+  },
+  listEmailEvents: {
     name: 'list-email-events',
     tags: ['all', 'email', 'list-email-events'],
   },
@@ -21,8 +21,8 @@ export const toolsConfig: Record<string, ToolsConfig> = {
   sendEmail: {
     name: 'send-email',
     tags: ['all', 'email', 'notification', 'send-email'],
-  }
-}
+  },
+};
 
 export type EmailToolKey = keyof typeof toolsConfig;
 
@@ -32,4 +32,4 @@ export const sha256 = (str: string): string => {
   const hash = crypto.createHash('sha256');
   hash.update(str);
   return hash.digest('hex');
-}
+};

--- a/src/tools/numbers/index.ts
+++ b/src/tools/numbers/index.ts
@@ -8,8 +8,8 @@ import { Tags } from '../../types';
 
 export const registerNumbersTools = (server: McpServer, tags: Tags[]) => {
   registerListAvailableRegions(server, tags);
-  registerListRentedNumbers(server, tags)
+  registerListRentedNumbers(server, tags);
   registerRentNumbers(server, tags);
   registerReleaseRentedNumber(server, tags);
-  registerSearchAvailableNumbers(server, tags)
-}
+  registerSearchAvailableNumbers(server, tags);
+};

--- a/src/tools/numbers/list-available-regions.ts
+++ b/src/tools/numbers/list-available-regions.ts
@@ -6,7 +6,10 @@ import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-
 import { getNumbersService } from './utils/numbers-service-helper';
 
 const ListAvailableRegionsSchema = {
-  types: z.array(z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE'])).optional().describe('Only return regions for which numbers are provided with the given types: MOBILE, LOCAL or TOLL_FREE.'),
+  types: z
+    .array(z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']))
+    .optional()
+    .describe('Only return regions for which numbers are provided with the given types: MOBILE, LOCAL or TOLL_FREE.'),
 };
 
 type ListAvailableRegions = z.infer<z.ZodObject<typeof ListAvailableRegionsSchema>>;
@@ -15,7 +18,9 @@ const TOOL_KEY: NumbersToolKey = 'listAvailableRegions';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListAvailableRegions = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -23,34 +28,33 @@ export const registerListAvailableRegions = (server: McpServer, tags: Tags[]) =>
       description: 'Lists all regions for numbers provided for the project ID.',
       inputSchema: ListAvailableRegionsSchema,
     },
-    listAvailableRegionsHandler
+    listAvailableRegionsHandler,
   );
-}
+};
 
-export const listAvailableRegionsHandler = async (
-  { types }: ListAvailableRegions
-) => {
-
+export const listAvailableRegionsHandler = async ({ types }: ListAvailableRegions) => {
   const maybeService = getNumbersService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;
   }
   const numbersService = maybeService;
 
-  try{
+  try {
     const response = await numbersService.availableRegions.list({
-      types
+      types,
     });
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      data: response.availableRegions
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        data: response.availableRegions,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error))
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
-
-
 };

--- a/src/tools/numbers/list-rented-numbers.ts
+++ b/src/tools/numbers/list-rented-numbers.ts
@@ -6,10 +6,26 @@ import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-
 import { Numbers } from '@sinch/numbers';
 
 const ListRentedNumbersSchema = {
-  regionCode: z.string().optional().describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
-  type: z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']).optional().describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
-  searchPattern: z.string().optional().describe('Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.'),
-  patternPosition: z.enum(['START', 'CONTAINS', 'END']).optional().describe('Position of the search pattern. Options include START, END or CONTAINS. If you want the search pattern to be at the beginning of the phone number, select START. If you want it at the end, select END. If you want it to be anywhere in the phone number, select CONTAINS.'),
+  regionCode: z
+    .string()
+    .optional()
+    .describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
+  type: z
+    .enum(['MOBILE', 'LOCAL', 'TOLL_FREE'])
+    .optional()
+    .describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
+  searchPattern: z
+    .string()
+    .optional()
+    .describe(
+      'Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.',
+    ),
+  patternPosition: z
+    .enum(['START', 'CONTAINS', 'END'])
+    .optional()
+    .describe(
+      'Position of the search pattern. Options include START, END or CONTAINS. If you want the search pattern to be at the beginning of the phone number, select START. If you want it at the end, select END. If you want it to be anywhere in the phone number, select CONTAINS.',
+    ),
   capability: z.enum(['SMS', 'VOICE']).optional().describe('Number capabilities to filter by SMS and/or VOICE.'),
   size: z.number().optional().describe('Maximum number of phone numbers to return.'),
 };
@@ -20,7 +36,9 @@ const TOOL_KEY: NumbersToolKey = 'listRentedNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerListRentedNumbers = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -28,33 +46,51 @@ export const registerListRentedNumbers = (server: McpServer, tags: Tags[]) => {
       description: 'Lists all active numbers for a project.',
       inputSchema: ListRentedNumbersSchema,
     },
-    listRentedNumbersHandler
+    listRentedNumbersHandler,
   );
-}
+};
 
-export const listRentedNumbersHandler = async (
-  { regionCode, type, searchPattern, patternPosition, capability, size }: ListRentedNumbers
-) => {
+export const listRentedNumbersHandler = async ({
+  regionCode,
+  type,
+  searchPattern,
+  patternPosition,
+  capability,
+  size,
+}: ListRentedNumbers) => {
   const projectId = process.env.PROJECT_ID;
-  const keyId     = process.env.KEY_ID;
+  const keyId = process.env.KEY_ID;
   const keySecret = process.env.KEY_SECRET;
 
   if (!projectId || !keyId || !keySecret) {
     return new PromptResponse(
       JSON.stringify({
         success: false,
-        error:'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.'
-      })).promptResponse;
+        error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.',
+      }),
+    ).promptResponse;
   }
 
   try {
     const queryParams = new URLSearchParams();
-    if (regionCode) queryParams.append('regionCode', regionCode);
-    if (type) queryParams.append('type', type);
-    if (searchPattern) queryParams.append('numberPattern.pattern', searchPattern);
-    if (patternPosition) queryParams.append('numberPattern.searchPattern', patternPosition);
-    if (capability) queryParams.append('capability', capability);
-    if (size) queryParams.append('pageSize', size.toString());
+    if (regionCode) {
+      queryParams.append('regionCode', regionCode);
+    }
+    if (type) {
+      queryParams.append('type', type);
+    }
+    if (searchPattern) {
+      queryParams.append('numberPattern.pattern', searchPattern);
+    }
+    if (patternPosition) {
+      queryParams.append('numberPattern.searchPattern', patternPosition);
+    }
+    if (capability) {
+      queryParams.append('capability', capability);
+    }
+    if (size) {
+      queryParams.append('pageSize', size.toString());
+    }
 
     const response = await fetch(
       `https://numbers.api.sinch.com/v1/projects/${projectId}/activeNumbers${queryParams.toString() ? '?' + queryParams.toString() : ''}`,
@@ -64,29 +100,33 @@ export const listRentedNumbersHandler = async (
           Authorization: 'Basic ' + Buffer.from(`${keyId}:${keySecret}`).toString('base64'),
           'User-Agent': formatUserAgent(TOOL_NAME, projectId),
         },
-      }
+      },
     );
 
     if (!response.ok) {
       const errorText = await response.text();
-      return new PromptResponse(JSON.stringify({
-        success: false,
-        error: `(${response.status} - ${response.statusText}) Failed to list the rented numbers: ${errorText}`
-      })).promptResponse;
+      return new PromptResponse(
+        JSON.stringify({
+          success: false,
+          error: `(${response.status} - ${response.statusText}) Failed to list the rented numbers: ${errorText}`,
+        }),
+      ).promptResponse;
     }
 
-    const parsedResponse = await response.json() as Numbers.ActiveNumbersResponse;
+    const parsedResponse = (await response.json()) as Numbers.ActiveNumbersResponse;
 
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      data: parsedResponse.activeNumbers
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        data: parsedResponse.activeNumbers,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error))
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
-
-
 };

--- a/src/tools/numbers/release-rented-number.ts
+++ b/src/tools/numbers/release-rented-number.ts
@@ -6,9 +6,7 @@ import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-
 import { getNumbersService } from './utils/numbers-service-helper';
 
 const ReleaseRentedNumberSchema = {
-  phoneNumber: z
-    .string()
-    .describe('The phone number in E.164 format with leading `+`'),
+  phoneNumber: z.string().describe('The phone number in E.164 format with leading `+`'),
 };
 
 type ReleaseRentedNumber = z.infer<z.ZodObject<typeof ReleaseRentedNumberSchema>>;
@@ -17,7 +15,9 @@ const TOOL_KEY: NumbersToolKey = 'releaseRentedNumber';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerReleaseRentedNumber = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -25,13 +25,11 @@ export const registerReleaseRentedNumber = (server: McpServer, tags: Tags[]) => 
       description: 'Releases a rented phone number from your project.',
       inputSchema: ReleaseRentedNumberSchema,
     },
-    releaseRentedNumberHandler
+    releaseRentedNumberHandler,
   );
 };
 
-export const releaseRentedNumberHandler = async ({
-  phoneNumber,
-}: ReleaseRentedNumber) => {
+export const releaseRentedNumberHandler = async ({ phoneNumber }: ReleaseRentedNumber) => {
   const maybeService = getNumbersService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;
@@ -44,16 +42,14 @@ export const releaseRentedNumberHandler = async ({
       JSON.stringify({
         success: true,
         data: response,
-      })
+      }),
     ).promptResponse;
   } catch (error) {
     return new PromptResponse(
       JSON.stringify({
         success: false,
-        error: `Failed to release number '${phoneNumber}': ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      })
+        error: `Failed to release number '${phoneNumber}': ${error instanceof Error ? error.message : String(error)}`,
+      }),
     ).promptResponse;
   }
 };

--- a/src/tools/numbers/rent-numbers.ts
+++ b/src/tools/numbers/rent-numbers.ts
@@ -7,7 +7,9 @@ import { getNumbersService } from './utils/numbers-service-helper';
 import { Numbers } from '@sinch/numbers';
 
 const RentNumbersSchema = {
-  numbers: z.array(z.string()).describe('Array of phone numbers to rent. Each number should be in E.164 format with leading `+`'),
+  numbers: z
+    .array(z.string())
+    .describe('Array of phone numbers to rent. Each number should be in E.164 format with leading `+`'),
 };
 
 type RentNumbers = z.infer<z.ZodObject<typeof RentNumbersSchema>>;
@@ -16,22 +18,22 @@ const TOOL_KEY: NumbersToolKey = 'rentNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerRentNumbers = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Activates a phone number that matches the search criteria provided in the request. Currently the rentAny operation works only for US LOCAL numbers',
+      description:
+        'Activates a phone number that matches the search criteria provided in the request. Currently the rentAny operation works only for US LOCAL numbers',
       inputSchema: RentNumbersSchema,
     },
-    rentNumbersHandler
+    rentNumbersHandler,
   );
-}
+};
 
-export const rentNumbersHandler = async (
-  { numbers }: RentNumbers
-) => {
-
+export const rentNumbersHandler = async ({ numbers }: RentNumbers) => {
   const maybeService = getNumbersService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;
@@ -45,25 +47,27 @@ export const rentNumbersHandler = async (
     try {
       const response = await numbersService.rent({
         phoneNumber: number,
-        rentNumberRequestBody: {}
+        rentNumberRequestBody: {},
       });
       successfulRentals.push({ number, details: response });
     } catch (error) {
       failedRentals.push({
         number,
-        error: error instanceof Error ? error.message : String(error)
+        error: error instanceof Error ? error.message : String(error),
       });
     }
   }
 
-  return new PromptResponse(JSON.stringify({
-    success: failedRentals.length === 0,
-    successful_rentals: successfulRentals,
-    failed_rentals: failedRentals,
-    summary: {
-      total: numbers.length,
-      successful: successfulRentals.length,
-      failed: failedRentals.length
-    }
-  })).promptResponse;
+  return new PromptResponse(
+    JSON.stringify({
+      success: failedRentals.length === 0,
+      successful_rentals: successfulRentals,
+      failed_rentals: failedRentals,
+      summary: {
+        total: numbers.length,
+        successful: successfulRentals.length,
+        failed: failedRentals.length,
+      },
+    }),
+  ).promptResponse;
 };

--- a/src/tools/numbers/search-for-available-numbers.ts
+++ b/src/tools/numbers/search-for-available-numbers.ts
@@ -6,11 +6,28 @@ import { getToolName, NumbersToolKey, toolsConfig } from './utils/numbers-tools-
 import { getNumbersService } from './utils/numbers-service-helper';
 
 const SearchAvailableNumbersSchema = {
-  regionCode: z.string().describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
-  type: z.enum(['MOBILE', 'LOCAL', 'TOLL_FREE']).describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
-  searchPattern: z.string().optional().describe('Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.'),
-  patternPosition: z.enum(['START', 'CONTAINS', 'END']).optional().describe('Position of the search pattern. Options include START, END or CONTAINS. If you want the search pattern to be at the beginning of the phone number, select START. If you want it at the end, select END. If you want it to be anywhere in the phone number, select CONTAINS.'),
-  capabilities: z.array(z.enum(['SMS', 'VOICE'])).optional().describe('Number capabilities to filter by SMS and/or VOICE.'),
+  regionCode: z
+    .string()
+    .describe('Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. Example: US, GB or SE.'),
+  type: z
+    .enum(['MOBILE', 'LOCAL', 'TOLL_FREE'])
+    .describe('Number type to filter by. Options include, MOBILE, LOCAL or TOLL_FREE.'),
+  searchPattern: z
+    .string()
+    .optional()
+    .describe(
+      'Sequence of digits to search for. If you prefer or need certain digits in sequential order, you can enter the sequence of numbers here. For example, `2020`.',
+    ),
+  patternPosition: z
+    .enum(['START', 'CONTAINS', 'END'])
+    .optional()
+    .describe(
+      'Position of the search pattern. Options include START, END or CONTAINS. If you want the search pattern to be at the beginning of the phone number, select START. If you want it at the end, select END. If you want it to be anywhere in the phone number, select CONTAINS.',
+    ),
+  capabilities: z
+    .array(z.enum(['SMS', 'VOICE']))
+    .optional()
+    .describe('Number capabilities to filter by SMS and/or VOICE.'),
   size: z.number().optional().describe('Maximum number of phone numbers to return.'),
 };
 
@@ -20,29 +37,36 @@ const TOOL_KEY: NumbersToolKey = 'searchForAvailableNumbers';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerSearchAvailableNumbers = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Search for available phone numbers that are available for you to activate. You can filter by any property on the available number resource.',
+      description:
+        'Search for available phone numbers that are available for you to activate. You can filter by any property on the available number resource.',
       inputSchema: SearchAvailableNumbersSchema,
     },
-    searchAvailableNumbersHandler
+    searchAvailableNumbersHandler,
   );
-}
+};
 
-export const searchAvailableNumbersHandler = async (
-  { regionCode, type, searchPattern, patternPosition, capabilities, size }: SearchAvailableNumbers
-) => {
-
+export const searchAvailableNumbersHandler = async ({
+  regionCode,
+  type,
+  searchPattern,
+  patternPosition,
+  capabilities,
+  size,
+}: SearchAvailableNumbers) => {
   const maybeService = getNumbersService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;
   }
   const numbersService = maybeService;
 
-  try{
+  try {
     const response = await numbersService.searchForAvailableNumbers({
       regionCode,
       type,
@@ -51,16 +75,18 @@ export const searchAvailableNumbersHandler = async (
       capabilities,
       size,
     });
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      data: response.availableNumbers
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        data: response.availableNumbers,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: (error instanceof Error ? error.message : String(error))
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
-
-
 };

--- a/src/tools/numbers/utils/numbers-service-helper.ts
+++ b/src/tools/numbers/utils/numbers-service-helper.ts
@@ -9,18 +9,18 @@ import { NumbersService } from '@sinch/numbers';
 import { PromptResponse } from '../../../types';
 import { formatUserAgent } from '../../../utils';
 
-export function getNumbersService(
-  toolName: string
-): NumbersService | PromptResponse {
+export function getNumbersService(toolName: string): NumbersService | PromptResponse {
   const projectId = process.env.PROJECT_ID;
-  const keyId     = process.env.KEY_ID;
+  const keyId = process.env.KEY_ID;
   const keySecret = process.env.KEY_SECRET;
 
   if (!projectId || !keyId || !keySecret) {
-    return new PromptResponse(JSON.stringify({
+    return new PromptResponse(
+      JSON.stringify({
         success: false,
-        error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.'
-      }));
+        error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.',
+      }),
+    );
   }
 
   const numbersService = new NumbersService({});
@@ -29,10 +29,7 @@ export function getNumbersService(
     requestPlugins: [
       new Oauth2TokenRequest(keyId, keySecret),
       new AdditionalHeadersRequest({
-        headers: buildHeader(
-          'User-Agent',
-          formatUserAgent(toolName, projectId),
-        ),
+        headers: buildHeader('User-Agent', formatUserAgent(toolName, projectId)),
       }),
     ],
   });

--- a/src/tools/numbers/utils/numbers-tools-helper.ts
+++ b/src/tools/numbers/utils/numbers-tools-helper.ts
@@ -2,7 +2,7 @@ import { ToolsConfig } from '../../../types';
 
 const defineToolsConfig = <T extends Record<string, ToolsConfig>>(config: T) => {
   return config;
-}
+};
 
 export const toolsConfig = defineToolsConfig({
   listAvailableRegions: {
@@ -24,7 +24,7 @@ export const toolsConfig = defineToolsConfig({
   searchForAvailableNumbers: {
     name: 'search-for-available-numbers',
     tags: ['all', 'numbers', 'search-for-available-numbers'],
-  }
+  },
 });
 
 export type NumbersToolKey = keyof typeof toolsConfig;

--- a/src/tools/verification/number-lookup.ts
+++ b/src/tools/verification/number-lookup.ts
@@ -15,22 +15,22 @@ const TOOL_KEY: VerificationToolKey = 'numberLookup';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerNumberLookup = (server: McpServer, tags: Tags[]) => {
-  if(!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'With quick and easy access to Number Lookup, you can enhance your communications and keep your database as clean as a whistle. Number Lookup checks against first-party numbering sources and provides real-time feedback. Test numbers to ensure your recipients are ready and waiting to receive your messages!',
+      description:
+        'With quick and easy access to Number Lookup, you can enhance your communications and keep your database as clean as a whistle. Number Lookup checks against first-party numbering sources and provides real-time feedback. Test numbers to ensure your recipients are ready and waiting to receive your messages!',
       inputSchema: NumberLookupSchema,
     },
-    numberLookupHandler
+    numberLookupHandler,
   );
 };
 
-export const numberLookupHandler = async (
-  { phoneNumber }: NumberLookup
-): Promise<IPromptResponse> => {
-
+export const numberLookupHandler = async ({ phoneNumber }: NumberLookup): Promise<IPromptResponse> => {
   const maybeService = getNumberLookupService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;
@@ -41,18 +41,21 @@ export const numberLookupHandler = async (
     const response = await numberLookupService.lookup({
       numberLookupRequestBody: {
         number: phoneNumber,
-        features: ['LineType']
-      }
-    })
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      data: response
-    })).promptResponse;
+        features: ['LineType'],
+      },
+    });
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        data: response,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error:  `Failed to look up number '${phoneNumber}': ${error instanceof Error ? error.message : String(error)}`
-  })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: `Failed to look up number '${phoneNumber}': ${error instanceof Error ? error.message : String(error)}`,
+      }),
+    ).promptResponse;
   }
-
 };

--- a/src/tools/verification/report-sms-verification.ts
+++ b/src/tools/verification/report-sms-verification.ts
@@ -16,7 +16,9 @@ const TOOL_KEY: VerificationToolKey = 'reportSmsVerification';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerReportSmsVerification = (server: McpServer, tags: Tags[]) => {
-  if(!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -24,13 +26,14 @@ export const registerReportSmsVerification = (server: McpServer, tags: Tags[]) =
       description: 'Report the received verification code to verify it, using the phone number of the user',
       inputSchema: ReportSmsVerificationSchema,
     },
-    reportSmsVerificationHandler
+    reportSmsVerificationHandler,
   );
 };
 
-export const reportSmsVerificationHandler = async (
-  { phoneNumber, oneTimePassword }: ReportSmsVerification
-): Promise<IPromptResponse> => {
+export const reportSmsVerificationHandler = async ({
+  phoneNumber,
+  oneTimePassword,
+}: ReportSmsVerification): Promise<IPromptResponse> => {
   try {
     const maybeService = getVerificationService(TOOL_NAME);
     if (isPromptResponse(maybeService)) {
@@ -42,20 +45,24 @@ export const reportSmsVerificationHandler = async (
       endpoint: phoneNumber,
       reportSmsVerificationByIdentityRequestBody: {
         sms: {
-          code: oneTimePassword
-        }
-      }
+          code: oneTimePassword,
+        },
+      },
     });
 
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      verification_id: response.id,
-      status: response.status
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        verification_id: response.id,
+        status: response.status,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/verification/start-sms-verification.ts
+++ b/src/tools/verification/start-sms-verification.ts
@@ -15,21 +15,22 @@ const TOOL_KEY: VerificationToolKey = 'startSmsVerification';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerStartVerificationWithSms = (server: McpServer, tags: Tags[]) => {
-  if(!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, verificationToolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Start new phone number verification requests. If the request is successful, you should ask the user to enter the OTP they received on the phone number we are verifying.',
+      description:
+        'Start new phone number verification requests. If the request is successful, you should ask the user to enter the OTP they received on the phone number we are verifying.',
       inputSchema: StartSmsVerificationSchema,
     },
-    startSmsVerificationHandler
+    startSmsVerificationHandler,
   );
 };
 
-export const startSmsVerificationHandler = async (
-  { phoneNumber }: StartSmsVerification
-): Promise<IPromptResponse> => {
+export const startSmsVerificationHandler = async ({ phoneNumber }: StartSmsVerification): Promise<IPromptResponse> => {
   try {
     const maybeService = getVerificationService(TOOL_NAME);
     if (isPromptResponse(maybeService)) {
@@ -41,20 +42,24 @@ export const startSmsVerificationHandler = async (
       startVerificationWithSmsRequestBody: {
         identity: {
           type: 'number',
-          endpoint: phoneNumber
-        }
-      }
+          endpoint: phoneNumber,
+        },
+      },
     });
 
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      verification_id: response.id,
-      phone_number: phoneNumber
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        verification_id: response.id,
+        phone_number: phoneNumber,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/verification/utils/number-lookup-service-helper.ts
+++ b/src/tools/verification/utils/number-lookup-service-helper.ts
@@ -9,18 +9,18 @@ import { PromptResponse } from '../../../types';
 import { formatUserAgent } from '../../../utils';
 import { NumberLookupService } from '@sinch/number-lookup';
 
-export function getNumberLookupService(
-  toolName: string
-): NumberLookupService | PromptResponse {
+export function getNumberLookupService(toolName: string): NumberLookupService | PromptResponse {
   const projectId = process.env.PROJECT_ID;
-  const keyId     = process.env.KEY_ID;
+  const keyId = process.env.KEY_ID;
   const keySecret = process.env.KEY_SECRET;
 
   if (!projectId || !keyId || !keySecret) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.'
-    }));
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.',
+      }),
+    );
   }
 
   const numberLookupService = new NumberLookupService({});
@@ -29,10 +29,7 @@ export function getNumberLookupService(
     requestPlugins: [
       new Oauth2TokenRequest(keyId, keySecret),
       new AdditionalHeadersRequest({
-        headers: buildHeader(
-          'User-Agent',
-          formatUserAgent(toolName, projectId),
-        ),
+        headers: buildHeader('User-Agent', formatUserAgent(toolName, projectId)),
       }),
     ],
   });

--- a/src/tools/verification/utils/verification-service-helper.ts
+++ b/src/tools/verification/utils/verification-service-helper.ts
@@ -11,36 +11,26 @@ import { VerificationService } from '@sinch/verification';
 import { formatUserAgent } from '../../../utils';
 
 export const getVerificationService = (toolName: string): VerificationService | PromptResponse => {
-
   const applicationKey = process.env.APPLICATION_KEY;
   const applicationSecret = process.env.APPLICATION_SECRET;
 
   if (!applicationKey && !applicationSecret) {
-    return new PromptResponse(
-      'Missing environment variables: "APPLICATION_KEY" and "APPLICATION_SECRET".'
-    );
+    return new PromptResponse('Missing environment variables: "APPLICATION_KEY" and "APPLICATION_SECRET".');
   }
   if (!applicationKey) {
-    return new PromptResponse(
-      'Missing environment variable: "APPLICATION_KEY".'
-    );
+    return new PromptResponse('Missing environment variable: "APPLICATION_KEY".');
   }
   if (!applicationSecret) {
-    return new PromptResponse(
-      'Missing environment variable: "APPLICATION_SECRET".'
-    );
+    return new PromptResponse('Missing environment variable: "APPLICATION_SECRET".');
   }
 
-  const verificationService  = new VerificationService({});
+  const verificationService = new VerificationService({});
   const fetcher = new ApiFetchClient({
     requestPlugins: [
       new XTimestampRequest(),
       new SigningRequest(applicationKey, applicationSecret),
       new AdditionalHeadersRequest({
-        headers: buildHeader(
-          'User-Agent',
-          formatUserAgent(toolName, applicationKey),
-        ),
+        headers: buildHeader('User-Agent', formatUserAgent(toolName, applicationKey)),
       }),
     ],
   });

--- a/src/tools/verification/utils/verification-tools-helper.ts
+++ b/src/tools/verification/utils/verification-tools-helper.ts
@@ -12,8 +12,8 @@ export const verificationToolsConfig: Record<string, ToolsConfig> = {
   startSmsVerification: {
     name: 'start-sms-verification',
     tags: ['all', 'verification', 'start-sms-verification'],
-  }
-}
+  },
+};
 
 export type VerificationToolKey = keyof typeof verificationToolsConfig;
 

--- a/src/tools/voice/close-conference.ts
+++ b/src/tools/voice/close-conference.ts
@@ -15,7 +15,9 @@ const TOOL_KEY: VoiceToolKey = 'closeConference';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerCloseConference = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -23,13 +25,11 @@ export const registerCloseConference = (server: McpServer, tags: Tags[]) => {
       description: 'Close a conference callout',
       inputSchema: CloseConferenceSchema,
     },
-    closeConferenceHandler
+    closeConferenceHandler,
   );
 };
 
-export const closeConferenceHandler = async (
-  { conferenceId }: CloseConference
-): Promise<IPromptResponse> => {
+export const closeConferenceHandler = async ({ conferenceId }: CloseConference): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;
@@ -38,17 +38,21 @@ export const closeConferenceHandler = async (
 
   try {
     await voiceService.conferences.kickAll({
-      conferenceId
+      conferenceId,
     });
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      conference_id: conferenceId
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        conference_id: conferenceId,
+      }),
+    ).promptResponse;
   } catch (error) {
     console.error(`Error closing conference ${conferenceId}:`, error);
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/voice/conference.ts
+++ b/src/tools/voice/conference.ts
@@ -18,7 +18,9 @@ const TOOL_KEY: VoiceToolKey = 'conferenceCallout';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerConferenceCallout = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -26,13 +28,13 @@ export const registerConferenceCallout = (server: McpServer, tags: Tags[]) => {
       description: 'Call a phone number and connects it to a conference room when answered',
       inputSchema: ConferenceCalloutSchema,
     },
-    conferenceCalloutHandler
+    conferenceCalloutHandler,
   );
 };
 
 export const conferenceCalloutHandler = async ({
   phoneNumbers,
-  conferenceId
+  conferenceId,
 }: ConferenceCallout): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
@@ -46,8 +48,8 @@ export const conferenceCalloutHandler = async ({
     conferenceId = crypto.randomUUID();
   }
 
-  const errors: { phoneNumber: string, error: string }[] = [];
-  const successfulCalls: { phoneNumber: string, callId: string }[] = [];
+  const errors: { phoneNumber: string; error: string }[] = [];
+  const successfulCalls: { phoneNumber: string; callId: string }[] = [];
 
   for (const phoneNumber of phoneNumbers) {
     const request: Voice.ConferenceCalloutRequestData = {
@@ -56,13 +58,13 @@ export const conferenceCalloutHandler = async ({
         conferenceCallout: {
           destination: {
             type: 'number',
-            endpoint: phoneNumber
+            endpoint: phoneNumber,
           },
-          conferenceId
-        }
-      }
+          conferenceId,
+        },
+      },
     };
-    if(cli) {
+    if (cli) {
       request.conferenceCalloutRequestBody.conferenceCallout.cli = cli;
     }
 
@@ -71,27 +73,29 @@ export const conferenceCalloutHandler = async ({
       if (response.callId) {
         successfulCalls.push({
           phoneNumber: request.conferenceCalloutRequestBody.conferenceCallout.destination.endpoint,
-          callId: response.callId
+          callId: response.callId,
         });
       }
     } catch (error) {
       errors.push({
         phoneNumber: request.conferenceCalloutRequestBody.conferenceCallout.destination.endpoint,
-        error: (error as Error).message
+        error: (error as Error).message,
       });
     }
   }
 
-  return new PromptResponse(JSON.stringify({
-    success: true,
-    conference_id: conferenceId,
-    successful_calls: successfulCalls.map(call => ({
-      phone_number: call.phoneNumber,
-      call_id: call.callId
-    })),
-    failed_calls: errors.map(err => ({
-      phone_number: err.phoneNumber,
-      error: err.error
-    }))
-  })).promptResponse;
+  return new PromptResponse(
+    JSON.stringify({
+      success: true,
+      conference_id: conferenceId,
+      successful_calls: successfulCalls.map((call) => ({
+        phone_number: call.phoneNumber,
+        call_id: call.callId,
+      })),
+      failed_calls: errors.map((err) => ({
+        phone_number: err.phoneNumber,
+        error: err.error,
+      })),
+    }),
+  ).promptResponse;
 };

--- a/src/tools/voice/get-call-information.ts
+++ b/src/tools/voice/get-call-information.ts
@@ -15,7 +15,9 @@ const TOOL_KEY: VoiceToolKey = 'getCallInformation';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerGetCallInformation = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -23,7 +25,7 @@ export const registerGetCallInformation = (server: McpServer, tags: Tags[]) => {
       description: 'Get information about a call using its ID',
       inputSchema: GetCallInformationSchema,
     },
-    getCallInformationHandler
+    getCallInformationHandler,
   );
 };
 
@@ -37,14 +39,18 @@ export const getCallInformationHandler = async ({ callId }: GetCallInformation):
   try {
     const response = await voiceService.calls.get({ callId });
 
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      call_information: response
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        call_information: response,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
-}
+};

--- a/src/tools/voice/manage-conference-participant.ts
+++ b/src/tools/voice/manage-conference-participant.ts
@@ -17,21 +17,25 @@ const TOOL_KEY: VoiceToolKey = 'manageConferenceParticipant';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerManageConferenceParticipant = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Manage a conference participant. The conference is identified by the conference Id used in the callout, and the participants by the callId associated to their phone number when the conference callout to their number was made',
+      description:
+        'Manage a conference participant. The conference is identified by the conference Id used in the callout, and the participants by the callId associated to their phone number when the conference callout to their number was made',
       inputSchema: ManageConferenceParticipantSchema,
     },
-    manageConferenceParticipantHandler);
+    manageConferenceParticipantHandler,
+  );
 };
 
 export const manageConferenceParticipantHandler = async ({
   conferenceId,
   participantId,
-  action
+  action,
 }: ManageConferenceParticipant): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
@@ -44,20 +48,24 @@ export const manageConferenceParticipantHandler = async ({
       conferenceId,
       callId: participantId,
       manageParticipantRequestBody: {
-        command: action
-      }
+        command: action,
+      },
     });
 
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      conference_id: conferenceId,
-      participant_id: participantId,
-      action: action
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        conference_id: conferenceId,
+        participant_id: participantId,
+        action: action,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/voice/tts-callout.ts
+++ b/src/tools/voice/tts-callout.ts
@@ -17,7 +17,9 @@ const TOOL_KEY: VoiceToolKey = 'ttsCallout';
 const TOOL_NAME = getToolName(TOOL_KEY);
 
 export const registerTtsCallout = (server: McpServer, tags: Tags[]) => {
-  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) return;
+  if (!matchesAnyTag(tags, voiceToolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
 
   server.registerTool(
     TOOL_NAME,
@@ -25,14 +27,11 @@ export const registerTtsCallout = (server: McpServer, tags: Tags[]) => {
       description: 'Make a callout with a Text-To-Speech prompt',
       inputSchema: TtsCalloutSchema,
     },
-    ttsCalloutHandler
+    ttsCalloutHandler,
   );
 };
 
-export const ttsCalloutHandler = async ({
-  phoneNumber,
-  message
-}: TtsCallout): Promise<IPromptResponse> => {
+export const ttsCalloutHandler = async ({ phoneNumber, message }: TtsCallout): Promise<IPromptResponse> => {
   const maybeService = getVoiceService(TOOL_NAME);
   if (isPromptResponse(maybeService)) {
     return maybeService.promptResponse;
@@ -47,28 +46,32 @@ export const ttsCalloutHandler = async ({
       ttsCallout: {
         destination: {
           type: 'number',
-          endpoint: phoneNumber
+          endpoint: phoneNumber,
         },
-        text: message
-      }
-    }
+        text: message,
+      },
+    },
   };
-  if(cli) {
+  if (cli) {
     request.ttsCalloutRequestBody.ttsCallout.cli = cli;
   }
 
   try {
     const response = await voiceService.callouts.tts(request);
 
-    return new PromptResponse(JSON.stringify({
-      success: true,
-      call_id: response.callId,
-      destination: phoneNumber
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        call_id: response.callId,
+        destination: phoneNumber,
+      }),
+    ).promptResponse;
   } catch (error) {
-    return new PromptResponse(JSON.stringify({
-      success: false,
-      error: error instanceof Error ? error.message : String(error)
-    })).promptResponse;
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    ).promptResponse;
   }
 };

--- a/src/tools/voice/utils/voice-service-helper.ts
+++ b/src/tools/voice/utils/voice-service-helper.ts
@@ -13,36 +13,26 @@ import { VoiceService } from '@sinch/voice';
 import { formatUserAgent } from '../../../utils';
 
 export const getVoiceService = (toolName: string): VoiceService | PromptResponse => {
-
   const applicationKey = process.env.APPLICATION_KEY;
   const applicationSecret = process.env.APPLICATION_SECRET;
 
   if (!applicationKey && !applicationSecret) {
-    return new PromptResponse(
-      'Missing environment variables: "APPLICATION_KEY" and "APPLICATION_SECRET".'
-    );
+    return new PromptResponse('Missing environment variables: "APPLICATION_KEY" and "APPLICATION_SECRET".');
   }
   if (!applicationKey) {
-    return new PromptResponse(
-      'Missing environment variable: "APPLICATION_KEY".'
-    );
+    return new PromptResponse('Missing environment variable: "APPLICATION_KEY".');
   }
   if (!applicationSecret) {
-    return new PromptResponse(
-      'Missing environment variable: "APPLICATION_SECRET".'
-    );
+    return new PromptResponse('Missing environment variable: "APPLICATION_SECRET".');
   }
 
-  const voiceService  = new VoiceService({});
+  const voiceService = new VoiceService({});
   const fetcher = new ApiFetchClient({
     requestPlugins: [
       new XTimestampRequest(),
       new SigningRequest(applicationKey, applicationSecret),
       new AdditionalHeadersRequest({
-        headers: buildHeader(
-          'User-Agent',
-          formatUserAgent(toolName, applicationKey),
-        ),
+        headers: buildHeader('User-Agent', formatUserAgent(toolName, applicationKey)),
       }),
     ],
   });

--- a/src/tools/voice/utils/voice-tools-helper.ts
+++ b/src/tools/voice/utils/voice-tools-helper.ts
@@ -20,8 +20,8 @@ export const voiceToolsConfig: Record<string, ToolsConfig> = {
   getCallInformation: {
     name: 'get-call-information',
     tags: ['all', 'voice', 'notification', 'get-call-information'],
-  }
-}
+  },
+};
 
 export type VoiceToolKey = keyof typeof voiceToolsConfig;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,35 +1,35 @@
 // MCP types
 interface TextResponseContent {
-    [x: string]: unknown;
-    type: 'text';
-    text: string;
+  [x: string]: unknown;
+  type: 'text';
+  text: string;
 }
 
 export interface IPromptResponse {
-    [x: string]: unknown;
-    content: TextResponseContent[];
+  [x: string]: unknown;
+  content: TextResponseContent[];
 }
 
 export class PromptResponse {
-    constructor(content: string) {
-        this.promptResponse = {
-            role: 'assistant',
-            content: [
-                {
-                    type: 'text',
-                    text: content,
-                }
-            ]
-        };
-    }
+  constructor(content: string) {
+    this.promptResponse = {
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: content,
+        },
+      ],
+    };
+  }
 
-    promptResponse: IPromptResponse;
+  promptResponse: IPromptResponse;
 }
 
 // Tags to categorize tools
 export type Tags = 'all' | 'conversation' | 'verification' | 'voice' | 'email' | 'notification' | string;
 
 export interface ToolsConfig {
-    name: string;
-    tags: Tags[];
+  name: string;
+  tags: Tags[];
 }

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -1,4 +1,4 @@
 import process from 'process';
 import { version as mcpServerVersion } from '../package.json';
 
-export const USER_AGENT = `sinch-sdk/MCP-${mcpServerVersion} (JavaScript/${process.version}; {toolName}; {userId})`
+export const USER_AGENT = `sinch-sdk/MCP-${mcpServerVersion} (JavaScript/${process.version}; {toolName}; {userId})`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,19 +3,19 @@ import { USER_AGENT } from './user-agent';
 
 export const isPromptResponse = (x: any): x is PromptResponse => {
   return x instanceof PromptResponse;
-}
+};
 
-export const matchesAnyTag= (tags: string[], filteringTags: string[]): boolean => {
+export const matchesAnyTag = (tags: string[], filteringTags: string[]): boolean => {
   if (!filteringTags || filteringTags.length === 0) {
     return true;
   }
 
-  const normalizedTags = tags.map(tag => tag.toLowerCase());
-  const normalizedFilteringTags = filteringTags.map(tag => tag.toLowerCase());
+  const normalizedTags = tags.map((tag) => tag.toLowerCase());
+  const normalizedFilteringTags = filteringTags.map((tag) => tag.toLowerCase());
 
-  return normalizedTags.some(tag => normalizedFilteringTags.includes(tag));
-}
+  return normalizedTags.some((tag) => normalizedFilteringTags.includes(tag));
+};
 
 export const formatUserAgent = (toolName: string, userId: string): string => {
   return USER_AGENT.replace('{toolName}', toolName).replace('{userId}', userId);
-}
+};

--- a/tests/integration/list-tools.ts
+++ b/tests/integration/list-tools.ts
@@ -1,31 +1,37 @@
-import { Client } from "@modelcontextprotocol/sdk/client/index";
+import { Client } from '@modelcontextprotocol/sdk/client/index';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { z } from 'zod';
 
 export const listTools = async () => {
-  const client = new Client({ name: "test-client", version: "0.0.1" });
+  const client = new Client({ name: 'test-client', version: '0.0.1' });
   let toolsResponse: any;
   try {
-    await client.connect(new StdioClientTransport({
-      command: process.execPath,
-      args: ['dist/index.js'],
-      env: {
-        ...process.env,
-        PROJECT_ID: 'test-project-id',
-        KEY_ID: 'test-key-id',
-        KEY_SECRET: 'test-key-secret',
-        MAILGUN_API_KEY: 'test-mailgun-api-key',
-        APPLICATION_KEY: 'test-application-key',
-        APPLICATION_SECRET: 'test-application-secret',
-      }
-    }));
+    await client.connect(
+      new StdioClientTransport({
+        command: process.execPath,
+        args: ['dist/index.js'],
+        env: {
+          ...process.env,
+          PROJECT_ID: 'test-project-id',
+          KEY_ID: 'test-key-id',
+          KEY_SECRET: 'test-key-secret',
+          MAILGUN_API_KEY: 'test-mailgun-api-key',
+          APPLICATION_KEY: 'test-application-key',
+          APPLICATION_SECRET: 'test-application-secret',
+        },
+      }),
+    );
 
-    toolsResponse = await client.request({
-      method: "tools/list"
-    }, z.any(), {});
+    toolsResponse = await client.request(
+      {
+        method: 'tools/list',
+      },
+      z.any(),
+      {},
+    );
   } finally {
     await client.close();
   }
 
   return toolsResponse.tools;
-}
+};

--- a/tests/integration/llms/anthropic.int.test.ts
+++ b/tests/integration/llms/anthropic.int.test.ts
@@ -9,12 +9,11 @@ const transformToAnthropicFormat = (tools: any[]): Anthropic.Messages.Tool[] => 
     description: t.description,
     input_schema: t.inputSchema,
   }));
-}
+};
 
 const targetModel = process.env.TARGET_MODEL || 'claude-3-7-sonnet-latest';
 
 describe(`Tool invocation tests - Anthropic - ${targetModel}`, () => {
-
   let tools: Anthropic.Messages.Tool[];
   let anthropic: Anthropic;
 
@@ -31,9 +30,7 @@ describe(`Tool invocation tests - Anthropic - ${targetModel}`, () => {
       const response = await anthropic.messages.create({
         model: targetModel,
         max_tokens: MAX_TOKENS,
-        messages: [
-          {role: 'user', content: prompt}
-        ],
+        messages: [{ role: 'user', content: prompt }],
         tools,
         temperature: TEMPERATURE,
         tool_choice: {
@@ -41,9 +38,7 @@ describe(`Tool invocation tests - Anthropic - ${targetModel}`, () => {
         },
       });
 
-      const toolCall = response.content.find(
-        (obj) => obj.type === "tool_use"
-      );
+      const toolCall = response.content.find((obj) => obj.type === 'tool_use');
 
       if (!expectedToolName) {
         expect(toolCall).toBeUndefined();
@@ -57,7 +52,6 @@ describe(`Tool invocation tests - Anthropic - ${targetModel}`, () => {
         expect(toolCall!.input).toEqual(expectedArguments);
       }
     },
-    TIMEOUT
+    TIMEOUT,
   );
-
 });

--- a/tests/integration/llms/gemini.int.test.ts
+++ b/tests/integration/llms/gemini.int.test.ts
@@ -10,15 +10,14 @@ const transformToGeminiFormat = (tools: any[]): Tool[] => {
         name: t.name,
         description: t.description,
         parametersJsonSchema: t.inputSchema,
-      }
-    ]
+      },
+    ],
   }));
-}
+};
 
 const targetModel = process.env.TARGET_MODEL || 'gemini-2.0-flash';
 
 describe(`Tool invocation tests - Gemini - ${targetModel}`, () => {
-
   let tools: any[];
   let gemini: GoogleGenAI;
 
@@ -35,7 +34,7 @@ describe(`Tool invocation tests - Gemini - ${targetModel}`, () => {
       const response = await gemini.models.generateContent({
         model: targetModel,
         contents: {
-          text: prompt
+          text: prompt,
         },
         config: {
           maxOutputTokens: MAX_TOKENS,
@@ -43,17 +42,17 @@ describe(`Tool invocation tests - Gemini - ${targetModel}`, () => {
           tools: tools,
           toolConfig: {
             functionCallingConfig: {
-              mode: FunctionCallingConfigMode.AUTO
-            }
-          }
+              mode: FunctionCallingConfigMode.AUTO,
+            },
+          },
         },
       });
 
       expect(response.candidates).toBeDefined();
 
       const toolCall = response.candidates
-        ?.map(c => c.content?.parts?.find(p => p.functionCall)?.functionCall)
-        .find(fc => fc !== undefined);
+        ?.map((c) => c.content?.parts?.find((p) => p.functionCall)?.functionCall)
+        .find((fc) => fc !== undefined);
 
       if (!expectedToolName) {
         expect(toolCall).toBeUndefined();
@@ -67,7 +66,6 @@ describe(`Tool invocation tests - Gemini - ${targetModel}`, () => {
         expect(toolCall!.args).toEqual(expectedArguments);
       }
     },
-    TIMEOUT
+    TIMEOUT,
   );
-
 });

--- a/tests/integration/llms/openai.int.test.ts
+++ b/tests/integration/llms/openai.int.test.ts
@@ -1,4 +1,4 @@
-import OpenAI from "openai";
+import OpenAI from 'openai';
 import { Tool } from 'openai/resources/responses/responses';
 import { toolTestCases } from '../toolsTestCases';
 import { listTools } from '../list-tools';
@@ -9,15 +9,14 @@ const transformToOpenAIFormat = (tools: any[]): Tool[] => {
     type: 'function',
     name: t.name,
     description: t.description,
-    parameters: JSON.stringify(t.inputSchema) === JSON.stringify({ type: "object" }) ? null : t.inputSchema,
+    parameters: JSON.stringify(t.inputSchema) === JSON.stringify({ type: 'object' }) ? null : t.inputSchema,
     strict: false,
   }));
-}
+};
 
 const targetModel = process.env.TARGET_MODEL || 'gpt-4o-mini';
 
 describe(`Tool invocation tests - Open AI - ${targetModel}`, () => {
-
   let tools: Tool[];
   let openai: OpenAI;
 
@@ -40,9 +39,7 @@ describe(`Tool invocation tests - Open AI - ${targetModel}`, () => {
         tool_choice: 'auto',
       });
 
-      const toolCall = response.output.find(
-        (obj) => obj.type === "function_call"
-      );
+      const toolCall = response.output.find((obj) => obj.type === 'function_call');
 
       if (!expectedToolName) {
         expect(toolCall).toBeUndefined();
@@ -56,7 +53,6 @@ describe(`Tool invocation tests - Open AI - ${targetModel}`, () => {
         expect(JSON.parse(toolCall!.arguments)).toEqual(expectedArguments);
       }
     },
-    TIMEOUT
+    TIMEOUT,
   );
-
 });

--- a/tests/integration/toolsTestCases.ts
+++ b/tests/integration/toolsTestCases.ts
@@ -7,22 +7,23 @@ export interface ToolTestCase {
 // Improvement: use types from the tools input schema
 export const toolTestCases: ToolTestCase[] = [
   {
-    prompt: "Which tools are available in the MCP server?",
-    expectedToolName: "sinch-mcp-configuration",
+    prompt: 'Which tools are available in the MCP server?',
+    expectedToolName: 'sinch-mcp-configuration',
     expectedArguments: undefined,
   },
   {
     prompt: "Send a text message to +33612345678 saying 'Hello there!'",
-    expectedToolName: "send-text-message",
+    expectedToolName: 'send-text-message',
     expectedArguments: {
-      recipient: "+33612345678",
-      message: "Hello there!",
-      channel: ["SMS"],
+      recipient: '+33612345678',
+      message: 'Hello there!',
+      channel: ['SMS'],
     },
   },
   {
-    prompt: "Send the product brochure PDF located at https://bit.ly/ABCDEF to the phone number +33612345678 on WhatsApp.",
-    expectedToolName: "send-media-message",
+    prompt:
+      'Send the product brochure PDF located at https://bit.ly/ABCDEF to the phone number +33612345678 on WhatsApp.',
+    expectedToolName: 'send-media-message',
     expectedArguments: {
       recipient: '+33612345678',
       url: 'https://bit.ly/ABCDEF',
@@ -30,180 +31,179 @@ export const toolTestCases: ToolTestCase[] = [
     },
   },
   {
-    prompt: "Send a whatsapp message to +33612345678 with the template 'appt_reminder' in Spanish, with the parameter 'name' set to 'Mr. Smith'.",
-    expectedToolName: "send-template-message",
+    prompt:
+      "Send a whatsapp message to +33612345678 with the template 'appt_reminder' in Spanish, with the parameter 'name' set to 'Mr. Smith'.",
+    expectedToolName: 'send-template-message',
     expectedArguments: {
-      recipient: "+33612345678",
-      whatsAppTemplateName: "appt_reminder",
-      whatsAppTemplateLanguage: "es",
+      recipient: '+33612345678',
+      whatsAppTemplateName: 'appt_reminder',
+      whatsAppTemplateLanguage: 'es',
       channel: ['WHATSAPP'],
       parameters: {
-        name: "Mr. Smith",
-      }
-    },
-  },
-  {
-    prompt: "Send a RCS survey about preferred ice cream flavor to +33612345678 with the following choices: Vanilla, Strawberry, Hazelnut",
-    expectedToolName: "send-choice-message",
-    expectedArguments: {
-      recipient: "+33612345678",
-      channel: ["RCS"],
-      text: "What is your preferred ice cream flavor?",
-      choiceContent: [
-        { text: "Vanilla" },
-        { text: "Strawberry" },
-        { text: "Hazelnut" },
-      ],
-    },
-  },
-  {
-    prompt: "Send a pin to the Guggenheim Museum location, Avenida Abandoibarra, 2 - 48009 Bilbao, Spain by SMS to the phone number +33612345678.",
-    expectedToolName: "send-location-message",
-    expectedArguments: {
-      recipient: "+33612345678",
-      address: {
-        address: "Avenida Abandoibarra, 2 - 48009 Bilbao, Spain"
+        name: 'Mr. Smith',
       },
-      channel: ["SMS"],
     },
   },
   {
-    prompt: "What messaging apps do I have set up in my account?",
-    expectedToolName: "list-conversation-apps",
+    prompt:
+      'Send a RCS survey about preferred ice cream flavor to +33612345678 with the following choices: Vanilla, Strawberry, Hazelnut',
+    expectedToolName: 'send-choice-message',
+    expectedArguments: {
+      recipient: '+33612345678',
+      channel: ['RCS'],
+      text: 'What is your preferred ice cream flavor?',
+      choiceContent: [{ text: 'Vanilla' }, { text: 'Strawberry' }, { text: 'Hazelnut' }],
+    },
+  },
+  {
+    prompt:
+      'Send a pin to the Guggenheim Museum location, Avenida Abandoibarra, 2 - 48009 Bilbao, Spain by SMS to the phone number +33612345678.',
+    expectedToolName: 'send-location-message',
+    expectedArguments: {
+      recipient: '+33612345678',
+      address: {
+        address: 'Avenida Abandoibarra, 2 - 48009 Bilbao, Spain',
+      },
+      channel: ['SMS'],
+    },
+  },
+  {
+    prompt: 'What messaging apps do I have set up in my account?',
+    expectedToolName: 'list-conversation-apps',
     expectedArguments: undefined,
   },
   {
-    prompt: "Create a Conversation app named Customer Support in the us region.",
-    expectedToolName: "create-conversation-app",
+    prompt: 'Create a Conversation app named Customer Support in the us region.',
+    expectedToolName: 'create-conversation-app',
     expectedArguments: {
-      displayName: "Customer Support",
-      region: "us",
+      displayName: 'Customer Support',
+      region: 'us',
     },
   },
   {
-    prompt: "Set SMS on Conversation app app-abc123 with service plan plan-456 and API token my-token.",
-    expectedToolName: "set-sms-channel-on-app",
+    prompt: 'Set SMS on Conversation app app-abc123 with service plan plan-456 and API token my-token.',
+    expectedToolName: 'set-sms-channel-on-app',
     expectedArguments: {
-      appId: "app-abc123",
-      servicePlanId: "plan-456",
-      apiToken: "my-token",
+      appId: 'app-abc123',
+      servicePlanId: 'plan-456',
+      apiToken: 'my-token',
     },
   },
   {
-    prompt: "Show me all message templates in my account.",
-    expectedToolName: "list-messaging-templates",
+    prompt: 'Show me all message templates in my account.',
+    expectedToolName: 'list-messaging-templates',
     expectedArguments: undefined,
   },
   {
-    prompt: "List all webhooks for my Conversation app.",
-    expectedToolName: "list-webhooks",
+    prompt: 'List all webhooks for my Conversation app.',
+    expectedToolName: 'list-webhooks',
     expectedArguments: undefined,
   },
   {
-    prompt: "Create a webhook for inbound messages at https://example.com/callback with triggers MESSAGE_INBOUND.",
-    expectedToolName: "create-webhook",
+    prompt: 'Create a webhook for inbound messages at https://example.com/callback with triggers MESSAGE_INBOUND.',
+    expectedToolName: 'create-webhook',
     expectedArguments: {
-      target: "https://example.com/callback",
-      triggers: ["MESSAGE_INBOUND"],
+      target: 'https://example.com/callback',
+      triggers: ['MESSAGE_INBOUND'],
     },
   },
   {
-    prompt: "Remove all triggers from webhook wh-abc123.",
-    expectedToolName: "update-webhook",
+    prompt: 'Remove all triggers from webhook wh-abc123.',
+    expectedToolName: 'update-webhook',
     expectedArguments: {
-      webhookId: "wh-abc123",
+      webhookId: 'wh-abc123',
       triggers: [],
     },
   },
   {
-    prompt: "Lookup for the following phone number capabilities: +33612345678",
-    expectedToolName: "number-lookup",
-    expectedArguments: { phoneNumber: "+33612345678" },
+    prompt: 'Lookup for the following phone number capabilities: +33612345678',
+    expectedToolName: 'number-lookup',
+    expectedArguments: { phoneNumber: '+33612345678' },
   },
   {
-    prompt: "Verify the phone number +33612345678",
-    expectedToolName: "start-sms-verification",
-    expectedArguments: { phoneNumber: "+33612345678" },
+    prompt: 'Verify the phone number +33612345678',
+    expectedToolName: 'start-sms-verification',
+    expectedArguments: { phoneNumber: '+33612345678' },
   },
   {
-    prompt: "Finalize the phone number +33612345678 verification with this code: 1234",
-    expectedToolName: "report-sms-verification",
+    prompt: 'Finalize the phone number +33612345678 verification with this code: 1234',
+    expectedToolName: 'report-sms-verification',
     expectedArguments: {
-      phoneNumber: "+33612345678",
-      oneTimePassword: "1234"
+      phoneNumber: '+33612345678',
+      oneTimePassword: '1234',
     },
   },
   {
     prompt: "Send an email to test@example.com saying 'Hello there!' with subject 'Hello'",
-    expectedToolName: "send-email",
+    expectedToolName: 'send-email',
     expectedArguments: {
-      recipient: "test@example.com",
-      subject: "Hello",
-      body: "Hello there!",
+      recipient: 'test@example.com',
+      subject: 'Hello',
+      body: 'Hello there!',
     },
   },
   {
-    prompt: "What email templates do I have available?",
-    expectedToolName: "list-email-templates",
+    prompt: 'What email templates do I have available?',
+    expectedToolName: 'list-email-templates',
     expectedArguments: undefined,
   },
   {
-    prompt: "Can you get the delivery status of the email with ID abcdef1234?",
-    expectedToolName: "retrieve-email-info",
+    prompt: 'Can you get the delivery status of the email with ID abcdef1234?',
+    expectedToolName: 'retrieve-email-info',
     expectedArguments: {
-      emailId: "abcdef1234"
+      emailId: 'abcdef1234',
     },
   },
   {
-    prompt: "Show me all email activity for my account between 2025-08-18T00:00:00Z and 2025-08-21T00:00:00Z.",
-    expectedToolName: "list-email-events",
+    prompt: 'Show me all email activity for my account between 2025-08-18T00:00:00Z and 2025-08-21T00:00:00Z.',
+    expectedToolName: 'list-email-events',
     expectedArguments: {
-      beginSearchPeriod: "2025-08-18T00:00:00Z",
-      endSearchPeriod: "2025-08-21T00:00:00Z",
+      beginSearchPeriod: '2025-08-18T00:00:00Z',
+      endSearchPeriod: '2025-08-21T00:00:00Z',
     },
   },
   {
-    prompt: "What are the open rates between Mon, 18 Aug 2025 00:00:00 +0100 and Thu, 21 Aug 2025 00:00:00 +0100?",
-    expectedToolName: "analytics-metrics",
+    prompt: 'What are the open rates between Mon, 18 Aug 2025 00:00:00 +0100 and Thu, 21 Aug 2025 00:00:00 +0100?',
+    expectedToolName: 'analytics-metrics',
     expectedArguments: {
-      beginSearchPeriod: "Mon, 18 Aug 2025 00:00:00 +0100",
-      endSearchPeriod: "Thu, 21 Aug 2025 00:00:00 +0100",
-      metrics: ["opened_rate"],
+      beginSearchPeriod: 'Mon, 18 Aug 2025 00:00:00 +0100',
+      endSearchPeriod: 'Thu, 21 Aug 2025 00:00:00 +0100',
+      metrics: ['opened_rate'],
     },
   },
   {
     prompt: "Call the phone number +33612345678 and say: 'Your appointment is tomorrow at 10 AM.'",
-    expectedToolName: "tts-callout",
+    expectedToolName: 'tts-callout',
     expectedArguments: {
-      phoneNumber: "+33612345678",
-      message: "Your appointment is tomorrow at 10 AM.",
+      phoneNumber: '+33612345678',
+      message: 'Your appointment is tomorrow at 10 AM.',
     },
   },
   {
-    prompt: "Call John (+33612345678) and Lisa (+34987654321) and connect them to a conference room.",
-    expectedToolName: "conference-callout",
+    prompt: 'Call John (+33612345678) and Lisa (+34987654321) and connect them to a conference room.',
+    expectedToolName: 'conference-callout',
     expectedArguments: {
-      phoneNumbers: ['+33612345678', '+34987654321']
+      phoneNumbers: ['+33612345678', '+34987654321'],
     },
   },
   {
-    prompt: "Mute the caller xyz789 in the conference abc123.",
-    expectedToolName: "manage-conference-participant",
+    prompt: 'Mute the caller xyz789 in the conference abc123.',
+    expectedToolName: 'manage-conference-participant',
     expectedArguments: {
-      conferenceId: "abc123",
-      participantId: "xyz789",
-      action: "mute"
+      conferenceId: 'abc123',
+      participantId: 'xyz789',
+      action: 'mute',
     },
   },
   {
-    prompt: "End the current conference call abc123.",
-    expectedToolName: "close-conference",
+    prompt: 'End the current conference call abc123.',
+    expectedToolName: 'close-conference',
     expectedArguments: {
-      conferenceId: "abc123"
+      conferenceId: 'abc123',
     },
   },
   {
-    prompt: "Just say hi",
+    prompt: 'Just say hi',
     expectedToolName: undefined,
   },
 ];

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4,29 +4,35 @@ import { registerCapabilities } from '../src/server';
 import * as path from 'path';
 import * as fs from 'fs';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 const loadTestCases = (useCase: string) => {
   const fixturesDir = path.join(__dirname, 'fixtures', 'server', useCase);
   const files = fs.readdirSync(fixturesDir);
-  return files.filter(file => file.endsWith('.json')).map(file => {
-    const filePath = path.join(fixturesDir, file);
-    const content = fs.readFileSync(filePath, 'utf-8');
-    return JSON.parse(content);
-  });
+  return files
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => {
+      const filePath = path.join(fixturesDir, file);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      return JSON.parse(content);
+    });
 };
 
 const getRegisteredToolNames = (server: McpServer) => {
   const tools = (server as any)._registeredTools;
   return tools ? Object.keys(tools).sort() : [];
-}
+};
 
 const getRegisteredPromptNames = (server: McpServer) => {
   const prompts = (server as any)._registeredPrompts;
   return prompts ? Object.keys(prompts).sort() : [];
-}
+};
 
 const setEnvVariables = () => {
   process.env.MAILGUN_API_KEY = 'test-mailgun-api-key';
@@ -35,7 +41,7 @@ const setEnvVariables = () => {
   process.env.KEY_SECRET = 'test-key-secret';
   process.env.APPLICATION_KEY = 'test-application-key';
   process.env.APPLICATION_SECRET = 'test-application-secret';
-}
+};
 
 interface TagFilteringTestCase {
   tag: Tags;
@@ -44,17 +50,20 @@ interface TagFilteringTestCase {
 }
 
 describe('MCP Server capability registration', () => {
-
   const testCases: TagFilteringTestCase[] = loadTestCases('tag-filtering');
 
   beforeEach(() => {
     setEnvVariables();
-  })
+  });
 
   for (const testCase of testCases) {
     it(`registers tools and prompts matching the '${testCase.tag}' tag`, () => {
       // Given
-      const server = new McpServer({ name: 'Test', version: 'test', capabilities: { resources: {}, tools: {}, prompts: {} } });
+      const server = new McpServer({
+        name: 'Test',
+        version: 'test',
+        capabilities: { resources: {}, tools: {}, prompts: {} },
+      });
       // When
       registerCapabilities(server, [testCase.tag]);
       // Then
@@ -67,20 +76,27 @@ describe('MCP Server capability registration', () => {
 
   it('registers all tools and prompts when no tags are provided', () => {
     // Given
-    const server = new McpServer({ name: 'Test', version: 'test', capabilities: { resources: {}, tools: {}, prompts: {} } });
+    const server = new McpServer({
+      name: 'Test',
+      version: 'test',
+      capabilities: { resources: {}, tools: {}, prompts: {} },
+    });
     // When
     registerCapabilities(server, []);
     // Then
     const tools = getRegisteredToolNames(server);
-    expect(tools).toEqual(testCases
-      .filter((testCase) => testCase.tag === 'all')
-      .flatMap((testCase) => testCase.expectedTools)
-      .sort()
+    expect(tools).toEqual(
+      testCases
+        .filter((testCase) => testCase.tag === 'all')
+        .flatMap((testCase) => testCase.expectedTools)
+        .sort(),
     );
     const prompts = getRegisteredPromptNames(server);
-    expect(prompts).toEqual(testCases
-      .filter((testCase) => testCase.tag === 'all')
-      .flatMap((testCase) => testCase.expectedPrompts)
-      .sort());
+    expect(prompts).toEqual(
+      testCases
+        .filter((testCase) => testCase.tag === 'all')
+        .flatMap((testCase) => testCase.expectedPrompts)
+        .sort(),
+    );
   });
 });

--- a/tests/tools/conversation/create-conversation-app.test.ts
+++ b/tests/tools/conversation/create-conversation-app.test.ts
@@ -1,9 +1,13 @@
 import { createConversationAppHandler } from '../../../src/tools/conversation/create-conversation-app';
 import { getConversationService } from '../../../src/tools/conversation/utils/conversation-service-helper';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 jest.mock('../../../src/tools/conversation/utils/conversation-service-helper', () => ({
   getConversationService: jest.fn(),

--- a/tests/tools/conversation/create-webhook.test.ts
+++ b/tests/tools/conversation/create-webhook.test.ts
@@ -5,9 +5,13 @@ import {
 } from '../../../src/tools/conversation/utils/conversation-service-helper';
 import { buildDormantTriggersWarning } from '../../../src/tools/conversation/utils/webhook-tools-helper';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 jest.mock('../../../src/tools/conversation/utils/conversation-service-helper', () => ({
   getConversationService: jest.fn(),

--- a/tests/tools/conversation/list-all-apps.test.ts
+++ b/tests/tools/conversation/list-all-apps.test.ts
@@ -1,11 +1,13 @@
 import { listAllAppsHandler } from '../../../src/tools/conversation/list-all-apps';
-import {
-  getConversationService,
-} from '../../../src/tools/conversation/utils/conversation-service-helper';
+import { getConversationService } from '../../../src/tools/conversation/utils/conversation-service-helper';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 jest.mock('../../../src/tools/conversation/utils/conversation-service-helper', () => ({
   getConversationService: jest.fn(),
@@ -20,28 +22,30 @@ const listMock = jest.fn();
 listMock.mockImplementation(() => {
   if (currentRegion === 'us') {
     return Promise.resolve({
-      apps: [{
-        id: 'us1',
-        displayName: 'App US',
-        channel_credentials: [
-          {channel: 'WHATSAPP', callback_secret: "pa$$word", state: {status: 'ACTIVE'}},
-        ]
-      }]
+      apps: [
+        {
+          id: 'us1',
+          displayName: 'App US',
+          channel_credentials: [{ channel: 'WHATSAPP', callback_secret: 'pa$$word', state: { status: 'ACTIVE' } }],
+        },
+      ],
     });
   } else if (currentRegion === 'eu') {
     return Promise.resolve({
-      apps: []
+      apps: [],
     });
   } else if (currentRegion === 'br') {
     return Promise.resolve({
-      apps: [{
-        id: 'br1',
-        displayName: 'App BR',
-        channel_credentials: [
-          {channel: 'MESSENGER', static_token: {token: '{Facebook_Token}'}, state: {status: 'ACTIVE'}},
-          {channel: 'RCS', state: {status: 'ACTIVE'}}
-        ]
-      }]
+      apps: [
+        {
+          id: 'br1',
+          displayName: 'App BR',
+          channel_credentials: [
+            { channel: 'MESSENGER', static_token: { token: '{Facebook_Token}' }, state: { status: 'ACTIVE' } },
+            { channel: 'RCS', state: { status: 'ACTIVE' } },
+          ],
+        },
+      ],
     });
   }
   return Promise.resolve([]);
@@ -85,14 +89,14 @@ test('listAllAppsHandler returns formatted app list for all regions', async () =
     apps: [
       {
         id: 'us1',
-        channel_credentials: [{ 'channel': 'WHATSAPP' }],
-        region: 'us'
+        channel_credentials: [{ channel: 'WHATSAPP' }],
+        region: 'us',
       },
       {
         id: 'br1',
-        channel_credentials: [{ 'channel': 'MESSENGER' }, { 'channel': 'RCS' }],
+        channel_credentials: [{ channel: 'MESSENGER' }, { channel: 'RCS' }],
         region: 'br',
-      }
+      },
     ],
     total_count: 2,
   });
@@ -117,17 +121,17 @@ test('listAllAppsHandler returns error response on failure', async () => {
     errors: [
       {
         region: 'us',
-        error: 'Oops'
+        error: 'Oops',
       },
       {
         region: 'eu',
-        error: 'Oops'
+        error: 'Oops',
       },
       {
         region: 'br',
-        error: 'Oops'
-      }
-    ]
+        error: 'Oops',
+      },
+    ],
   });
   expect(result.content[0].text).toBe(expectedResponse);
 });

--- a/tests/tools/conversation/list-webhooks.test.ts
+++ b/tests/tools/conversation/list-webhooks.test.ts
@@ -4,9 +4,13 @@ import {
   getConversationService,
 } from '../../../src/tools/conversation/utils/conversation-service-helper';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 jest.mock('../../../src/tools/conversation/utils/conversation-service-helper', () => ({
   getConversationService: jest.fn(),
@@ -28,13 +32,15 @@ beforeEach(() => {
 
 test('listWebhooksHandler returns formatted webhooks without secrets', async () => {
   mockList.mockResolvedValue({
-    webhooks: [{
-      id: 'wh-1',
-      app_id: 'app-123',
-      target: 'https://example.com/hook',
-      triggers: ['MESSAGE_INBOUND'],
-      secret: 'must-not-appear',
-    }],
+    webhooks: [
+      {
+        id: 'wh-1',
+        app_id: 'app-123',
+        target: 'https://example.com/hook',
+        triggers: ['MESSAGE_INBOUND'],
+        secret: 'must-not-appear',
+      },
+    ],
   });
 
   const result = await listWebhooksHandler({});
@@ -42,13 +48,15 @@ test('listWebhooksHandler returns formatted webhooks without secrets', async () 
   expect(mockList).toHaveBeenCalledWith({ app_id: 'app-123' });
   expect(JSON.parse(result.content[0].text)).toEqual({
     success: true,
-    webhooks: [{
-      id: 'wh-1',
-      app_id: 'app-123',
-      target: 'https://example.com/hook',
-      target_type: undefined,
-      triggers: ['MESSAGE_INBOUND'],
-    }],
+    webhooks: [
+      {
+        id: 'wh-1',
+        app_id: 'app-123',
+        target: 'https://example.com/hook',
+        target_type: undefined,
+        triggers: ['MESSAGE_INBOUND'],
+      },
+    ],
     total_count: 1,
   });
 });

--- a/tests/tools/conversation/send-text-message.test.ts
+++ b/tests/tools/conversation/send-text-message.test.ts
@@ -6,9 +6,13 @@ import {
 } from '../../../src/tools/conversation/utils/conversation-service-helper';
 import { buildMessageBase } from '../../../src/tools/conversation/utils/send-message-builder';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 jest.mock('../../../src/tools/conversation/utils/conversation-service-helper');
 jest.mock('../../../src/tools/conversation/utils/send-message-builder');
@@ -42,8 +46,8 @@ test('sendTextMessageHandler returns success response', async () => {
   });
 
   const expectedResponse = JSON.stringify({
-    success:true,
-    message_id:'abc123'
+    success: true,
+    message_id: 'abc123',
   });
 
   expect(result.content[0].text).toEqual(expectedResponse);
@@ -64,8 +68,8 @@ test('sendTextMessageHandler returns error response on failure', async () => {
   });
 
   const expectedResponse = JSON.stringify({
-    success:false,
-    error:'Oops. Are you sure you are using the right region to send your message? The current region is eu.'
+    success: false,
+    error: 'Oops. Are you sure you are using the right region to send your message? The current region is eu.',
   });
 
   expect(result.content[0].text).toEqual(expectedResponse);

--- a/tests/tools/conversation/set-sms-channel-on-app.test.ts
+++ b/tests/tools/conversation/set-sms-channel-on-app.test.ts
@@ -1,9 +1,13 @@
 import { setSmsChannelOnAppHandler } from '../../../src/tools/conversation/set-sms-channel-on-app';
 import { getConversationService } from '../../../src/tools/conversation/utils/conversation-service-helper';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 jest.mock('../../../src/tools/conversation/utils/conversation-service-helper', () => ({
   getConversationService: jest.fn(),
@@ -28,12 +32,14 @@ beforeEach(() => {
 test('setSmsChannelOnAppHandler merges SMS credentials into the app', async () => {
   mockGet.mockResolvedValue({
     id: 'app-123',
-    channel_credentials: [{
-      channel: 'MESSENGER',
-      static_token: { token: 'fb-token' },
-      state: { status: 'ACTIVE' },
-      channel_known_id: 'page-1',
-    }],
+    channel_credentials: [
+      {
+        channel: 'MESSENGER',
+        static_token: { token: 'fb-token' },
+        state: { status: 'ACTIVE' },
+        channel_known_id: 'page-1',
+      },
+    ],
   });
   mockUpdate.mockResolvedValue({
     id: 'app-123',

--- a/tests/tools/conversation/update-webhook.test.ts
+++ b/tests/tools/conversation/update-webhook.test.ts
@@ -2,9 +2,13 @@ import { updateWebhookHandler } from '../../../src/tools/conversation/update-web
 import { getConversationService } from '../../../src/tools/conversation/utils/conversation-service-helper';
 import { buildDormantTriggersWarning } from '../../../src/tools/conversation/utils/webhook-tools-helper';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 jest.mock('../../../src/tools/conversation/utils/conversation-service-helper', () => ({
   getConversationService: jest.fn(),

--- a/tests/tools/conversation/utils/build-channel-credential.test.ts
+++ b/tests/tools/conversation/utils/build-channel-credential.test.ts
@@ -44,12 +44,14 @@ describe('buildWhatsAppChannelCredential', () => {
 
 describe('toChannelCredentialRequest', () => {
   test('omits response-only fields from PATCH payload', () => {
-    expect(toChannelCredentialRequest({
-      channel: 'SMS',
-      static_bearer: { claimed_identity: 'plan', token: 'secret' },
-      state: { status: 'ACTIVE' },
-      channel_known_id: 'known-id',
-    })).toEqual({
+    expect(
+      toChannelCredentialRequest({
+        channel: 'SMS',
+        static_bearer: { claimed_identity: 'plan', token: 'secret' },
+        state: { status: 'ACTIVE' },
+        channel_known_id: 'known-id',
+      }),
+    ).toEqual({
       channel: 'SMS',
       static_bearer: {
         claimed_identity: 'plan',

--- a/tests/tools/conversation/utils/conversation-service-helper.test.ts
+++ b/tests/tools/conversation/utils/conversation-service-helper.test.ts
@@ -9,9 +9,13 @@ import {
 import { PromptResponse } from '../../../../src/types';
 import { formatUserAgent } from '../../../../src/utils';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 describe('getConversationService / getConversationTemplateService', () => {
   const OLD_ENV = process.env;
@@ -39,7 +43,9 @@ describe('getConversationService / getConversationTemplateService', () => {
     expect(conversationFetchClient!.apiClientOptions.hostname).toBe(expectedHostname);
     expect(conversationFetchClient!.apiClientOptions.requestPlugins?.length).toBe(2);
 
-    const userAgentPlugin = conversationFetchClient!.apiClientOptions.requestPlugins?.find((plugin) => plugin.getName() === 'AdditionalHeadersRequest');
+    const userAgentPlugin = conversationFetchClient!.apiClientOptions.requestPlugins?.find(
+      (plugin) => plugin.getName() === 'AdditionalHeadersRequest',
+    );
     expect(userAgentPlugin).toBeDefined();
     const expectedUserAgent = formatUserAgent(TOOL_NAME, PROJECT_ID);
     expect((await (userAgentPlugin as any).additionalHeaders.headers)['User-Agent']).toBe(expectedUserAgent);
@@ -54,7 +60,9 @@ describe('getConversationService / getConversationTemplateService', () => {
     expect(templateFetchClient!.apiClientOptions.hostname).toBe(expectedHostname);
     expect(templateFetchClient!.apiClientOptions.requestPlugins?.length).toBe(2);
 
-    const userAgentPlugin = templateFetchClient!.apiClientOptions.requestPlugins?.find((plugin) => plugin.getName() === 'AdditionalHeadersRequest');
+    const userAgentPlugin = templateFetchClient!.apiClientOptions.requestPlugins?.find(
+      (plugin) => plugin.getName() === 'AdditionalHeadersRequest',
+    );
     expect(userAgentPlugin).toBeDefined();
     const expectedUserAgent = formatUserAgent(TOOL_NAME, PROJECT_ID);
     expect((await (userAgentPlugin as any).additionalHeaders.headers)['User-Agent']).toBe(expectedUserAgent);
@@ -64,16 +72,18 @@ describe('getConversationService / getConversationTemplateService', () => {
     const service = getConversationService(TOOL_NAME) as ConversationService;
     setConversationRegion('eu', service);
 
-    expect(service.lazyConversationClient.apiFetchClient!.apiClientOptions.hostname)
-      .toBe('https://eu.conversation.api.sinch.com');
+    expect(service.lazyConversationClient.apiFetchClient!.apiClientOptions.hostname).toBe(
+      'https://eu.conversation.api.sinch.com',
+    );
   });
 
   test('setTemplateRegion updates hostname to the given non-default region', () => {
     const service = getConversationService(TOOL_NAME) as ConversationService;
     setTemplateRegion('eu', service);
 
-    expect(service.lazyConversationTemplateClient.apiFetchClient!.apiClientOptions.hostname)
-      .toBe('https://eu.template.api.sinch.com');
+    expect(service.lazyConversationTemplateClient.apiFetchClient!.apiClientOptions.hostname).toBe(
+      'https://eu.template.api.sinch.com',
+    );
   });
 
   test('returns PromptResponse when env vars are missing', () => {
@@ -86,8 +96,8 @@ describe('getConversationService / getConversationTemplateService', () => {
         {
           type: 'text',
           text: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.',
-        }
-      ]
+        },
+      ],
     });
   });
 });
@@ -114,8 +124,8 @@ describe('getConversationAppId', () => {
         {
           type: 'text',
           text: 'The "CONVERSATION_APP_ID" is not set in the environment variables and the "appId" property is not provided.',
-        }
-      ]
+        },
+      ],
     });
   });
 });

--- a/tests/tools/conversation/utils/format-app-response.test.ts
+++ b/tests/tools/conversation/utils/format-app-response.test.ts
@@ -4,34 +4,40 @@ test('formatAppResponse includes claimed_identity for static bearer channels', (
   const formatted = formatAppResponse({
     id: 'app-1',
     display_name: 'Test',
-    channel_credentials: [{
-      channel: 'SMS',
-      static_bearer: {
-        claimed_identity: 'plan-123',
-        token: 'secret',
+    channel_credentials: [
+      {
+        channel: 'SMS',
+        static_bearer: {
+          claimed_identity: 'plan-123',
+          token: 'secret',
+        },
+        state: { status: 'ACTIVE' },
       },
-      state: { status: 'ACTIVE' },
-    }],
+    ],
   });
 
-  expect(formatted.channel_credentials).toEqual([{
-    channel: 'SMS',
-    status: 'ACTIVE',
-    claimed_identity: 'plan-123',
-  }]);
+  expect(formatted.channel_credentials).toEqual([
+    {
+      channel: 'SMS',
+      status: 'ACTIVE',
+      claimed_identity: 'plan-123',
+    },
+  ]);
 });
 
 test('formatAppResponse omits channel_known_id when undefined', () => {
   const formatted = formatAppResponse({
     id: 'app-1',
-    channel_credentials: [{
-      channel: 'RCS',
-      static_bearer: {
-        claimed_identity: 'sender-1',
-        token: 'secret',
+    channel_credentials: [
+      {
+        channel: 'RCS',
+        static_bearer: {
+          claimed_identity: 'sender-1',
+          token: 'secret',
+        },
+        state: { status: 'PENDING' },
       },
-      state: { status: 'PENDING' },
-    }],
+    ],
   });
 
   expect(formatted.channel_credentials?.[0]).not.toHaveProperty('channel_known_id');
@@ -40,21 +46,25 @@ test('formatAppResponse omits channel_known_id when undefined', () => {
 test('formatAppResponse includes channel_known_id when defined', () => {
   const formatted = formatAppResponse({
     id: 'app-1',
-    channel_credentials: [{
-      channel: 'SMS',
-      channel_known_id: 'page-123',
-      static_bearer: {
-        claimed_identity: 'plan-123',
-        token: 'secret',
+    channel_credentials: [
+      {
+        channel: 'SMS',
+        channel_known_id: 'page-123',
+        static_bearer: {
+          claimed_identity: 'plan-123',
+          token: 'secret',
+        },
+        state: { status: 'ACTIVE' },
       },
-      state: { status: 'ACTIVE' },
-    }],
+    ],
   });
 
-  expect(formatted.channel_credentials).toEqual([{
-    channel: 'SMS',
-    status: 'ACTIVE',
-    channel_known_id: 'page-123',
-    claimed_identity: 'plan-123',
-  }]);
+  expect(formatted.channel_credentials).toEqual([
+    {
+      channel: 'SMS',
+      status: 'ACTIVE',
+      channel_known_id: 'page-123',
+      claimed_identity: 'plan-123',
+    },
+  ]);
 });

--- a/tests/tools/conversation/utils/format-list-all-apps-response.test.ts
+++ b/tests/tools/conversation/utils/format-list-all-apps-response.test.ts
@@ -17,19 +17,19 @@ describe('formatListAllAppsResponse', () => {
               callback_secret: 'secret1',
               state: {
                 status: 'ACTIVE',
-                description: ''
+                description: '',
               },
               channel_known_id: '12345',
             },
             {
               channel: 'TELEGRAM',
               telegram_credentials: {
-                token: 'token2'
+                token: 'token2',
               },
               callback_secret: 'secret2',
               state: {
                 status: 'ACTIVE',
-                description: ''
+                description: '',
               },
               channel_known_id: '',
             },
@@ -42,24 +42,24 @@ describe('formatListAllAppsResponse', () => {
               callback_secret: '',
               state: {
                 status: 'FAILING',
-                description: ''
+                description: '',
               },
               channel_known_id: '',
-            }
+            },
           ],
           conversation_metadata_report_view: 'NONE',
           rate_limits: {
             outbound: 80,
             inbound: 100,
-            webhooks: 100
-          }
+            webhooks: 100,
+          },
         },
         {
           id: 'app2',
           display_name: 'App Two',
-          channel_credentials: []
-        }
-      ]
+          channel_credentials: [],
+        },
+      ],
     };
 
     const output = formatListAllAppsResponse(input);
@@ -68,17 +68,14 @@ describe('formatListAllAppsResponse', () => {
         {
           id: 'app1',
           display_name: 'App One',
-          channel_credentials: [
-            { channel: 'MESSENGER' },
-            { channel: 'TELEGRAM' }
-          ]
+          channel_credentials: [{ channel: 'MESSENGER' }, { channel: 'TELEGRAM' }],
         },
         {
           id: 'app2',
           display_name: 'App Two',
-          channel_credentials: []
-        }
-      ]
+          channel_credentials: [],
+        },
+      ],
     });
   });
 
@@ -87,5 +84,4 @@ describe('formatListAllAppsResponse', () => {
     const output = formatListAllAppsResponse(input);
     expect(output).toEqual({ apps: [] });
   });
-
 });

--- a/tests/tools/conversation/utils/format-list-all-templates-response.test.ts
+++ b/tests/tools/conversation/utils/format-list-all-templates-response.test.ts
@@ -1,7 +1,5 @@
 import { Conversation } from '@sinch/conversation';
-import {
-  formatListAllTemplatesResponse
-} from '../../../../src/tools/conversation/utils/format-list-all-templates-response';
+import { formatListAllTemplatesResponse } from '../../../../src/tools/conversation/utils/format-list-all-templates-response';
 
 describe('formatListAllTemplatesResponse', () => {
   it('should correctly format templates with all fields present', () => {
@@ -20,9 +18,9 @@ describe('formatListAllTemplatesResponse', () => {
               update_time: new Date('2024-07-17T14:37:36Z'),
               variables: [{ key: 'name', preview_value: 'Professor Jones' }],
               text_message: { text: 'Hello ${name}' },
-              channel_template_overrides: {}
+              channel_template_overrides: {},
             },
-            { language_code: 'fr-FR', version: '2', text_message: { text: 'Bonjour ${name}' }},
+            { language_code: 'fr-FR', version: '2', text_message: { text: 'Bonjour ${name}' } },
           ],
         },
       ],

--- a/tests/tools/conversation/utils/geocoding.test.ts
+++ b/tests/tools/conversation/utils/geocoding.test.ts
@@ -4,21 +4,23 @@ import { getLatitudeLongitudeFromAddress } from '../../../../src/tools/conversat
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const mockAddress = 'Phare d\'Eckmühl';
+const mockAddress = "Phare d'Eckmühl";
 
 const mockSuccessResponse = {
   data: {
     status: 'OK',
-    results: [{
-      formatted_address: 'Pl. du Maréchal Davout, 29760 Penmarch, France',
-      geometry: {
-        location: {
-          lat: 47.7981899,
-          lng: -4.372768499999999
-        }
-      }
-    }]
-  }
+    results: [
+      {
+        formatted_address: 'Pl. du Maréchal Davout, 29760 Penmarch, France',
+        geometry: {
+          location: {
+            lat: 47.7981899,
+            lng: -4.372768499999999,
+          },
+        },
+      },
+    ],
+  },
 };
 
 beforeEach(() => {
@@ -34,11 +36,11 @@ test('returns coordinates when API responds with OK', async () => {
   expect(result).toEqual({
     latitude: 47.7981899,
     longitude: -4.372768499999999,
-    formattedAddress: 'Pl. du Maréchal Davout, 29760 Penmarch, France'
+    formattedAddress: 'Pl. du Maréchal Davout, 29760 Penmarch, France',
   });
 
   expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('geocode/json'), {
-    params: { address: mockAddress, key: 'test-api-key' }
+    params: { address: mockAddress, key: 'test-api-key' },
   });
 });
 
@@ -51,7 +53,7 @@ test('returns fallback when API status is not OK', async () => {
   expect(result).toEqual({
     latitude: 0,
     longitude: 0,
-    formattedAddress: 'Unknown'
+    formattedAddress: 'Unknown',
   });
 
   expect(consoleSpy).toHaveBeenCalledWith('Geocoding failed:', 'ZERO_RESULTS');
@@ -67,7 +69,7 @@ test('returns fallback when axios throws', async () => {
   expect(result).toEqual({
     latitude: 0,
     longitude: 0,
-    formattedAddress: 'Unknown'
+    formattedAddress: 'Unknown',
   });
 
   expect(consoleSpy).toHaveBeenCalledWith('Request failed:', new Error('Network error'));
@@ -79,11 +81,14 @@ test('includes GEOCODING_API_KEY in query params', async () => {
 
   await getLatitudeLongitudeFromAddress(mockAddress);
 
-  expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
-    params: expect.objectContaining({
-      key: 'test-api-key'
-    })
-  }));
+  expect(mockedAxios.get).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({
+      params: expect.objectContaining({
+        key: 'test-api-key',
+      }),
+    }),
+  );
 });
 
 test('returns fallback when GEOCODING_API_KEY is not set', async () => {
@@ -98,14 +103,17 @@ test('returns fallback when GEOCODING_API_KEY is not set', async () => {
   expect(result).toEqual({
     latitude: 0,
     longitude: 0,
-    formattedAddress: 'Unknown'
+    formattedAddress: 'Unknown',
   });
 
-  expect(mockedAxios.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
-    params: expect.objectContaining({
-      key: undefined
-    })
-  }));
+  expect(mockedAxios.get).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({
+      params: expect.objectContaining({
+        key: undefined,
+      }),
+    }),
+  );
 
   expect(consoleSpy).toHaveBeenCalledWith('Request failed:', new Error('API key missing'));
   consoleSpy.mockRestore();

--- a/tests/tools/conversation/utils/send-message-builder.test.ts
+++ b/tests/tools/conversation/utils/send-message-builder.test.ts
@@ -5,15 +5,12 @@ const mockGetApp = jest.fn();
 
 const mockConversationService = {
   app: {
-    get: mockGetApp
-  }
+    get: mockGetApp,
+  },
 };
 
 const baseAppConfig = {
-  channel_credentials: [
-    { channel: 'WHATSAPP' },
-    { channel: 'SMS' }
-  ]
+  channel_credentials: [{ channel: 'WHATSAPP' }, { channel: 'SMS' }],
 } as Conversation.AppResponse;
 
 beforeEach(() => {
@@ -30,16 +27,16 @@ test('buildMessageBase sets correct base structure and adds SMS fallback when ne
     app_id: 'my-app-id',
     processing_strategy: 'DISPATCH_ONLY',
     channel_properties: {
-      SMS_SENDER: '+12014444333'
+      SMS_SENDER: '+12014444333',
     },
     recipient: {
       identified_by: {
         channel_identities: [
           { channel: 'WHATSAPP', identity: '+1234567890' },
-          { channel: 'SMS', identity: '+1234567890' } // fallback
-        ]
-      }
-    }
+          { channel: 'SMS', identity: '+1234567890' }, // fallback
+        ],
+      },
+    },
   });
 });
 
@@ -54,10 +51,13 @@ test('MMS fallback switches to SMS when MMS is not configured', async () => {
 test('No SMS fallback is added if already included', async () => {
   mockGetApp.mockResolvedValue(baseAppConfig);
 
-  const result = await buildMessageBase(mockConversationService as any, 'my-app-id', '+1234567890', ['WHATSAPP', 'SMS']);
+  const result = await buildMessageBase(mockConversationService as any, 'my-app-id', '+1234567890', [
+    'WHATSAPP',
+    'SMS',
+  ]);
 
-  const channels = result.recipient.identified_by.channel_identities.map(ci => ci.channel);
-  const smsCount = channels.filter(c => c === 'SMS').length;
+  const channels = result.recipient.identified_by.channel_identities.map((ci) => ci.channel);
+  const smsCount = channels.filter((c) => c === 'SMS').length;
 
   expect(smsCount).toBe(1); // only once
 });

--- a/tests/tools/email/analytics-metrics.test.ts
+++ b/tests/tools/email/analytics-metrics.test.ts
@@ -20,9 +20,7 @@ describe('analyticsMetricsHandler', () => {
       start: 'Mon, 02 Jun 2025 00:00:00 +0000',
       end: 'Mon, 09 Jun 2025 00:00:00 +0000',
       resolution: 'day',
-      dimensions: [
-        'time'
-      ],
+      dimensions: ['time'],
       items: [],
       aggregates: {
         metrics: {
@@ -32,15 +30,15 @@ describe('analyticsMetricsHandler', () => {
           opened_count: 5,
           clicked_count: 3,
           unsubscribed_count: 1,
-          complained_count: 0
-        }
-      }
+          complained_count: 0,
+        },
+      },
     };
 
     const mockedFetch = fetch as jest.Mock;
     mockedFetch.mockResolvedValue({
       ok: true,
-      json: async () => mockResponse
+      json: async () => mockResponse,
     });
 
     // When
@@ -60,8 +58,8 @@ describe('analyticsMetricsHandler', () => {
       },
       period: {
         begin: 'Mon, 02 Jun 2025 00:00:00 +0000',
-        end: 'Mon, 09 Jun 2025 00:00:00 +0000'
-      }
+        end: 'Mon, 09 Jun 2025 00:00:00 +0000',
+      },
     });
     expect(result.role).toBe('assistant');
     expect(result.content[0].text).toBe(expectedText);
@@ -86,7 +84,7 @@ describe('analyticsMetricsHandler', () => {
     (fetch as jest.Mock).mockResolvedValue({
       ok: false,
       status: 403,
-      statusText: 'Forbidden'
+      statusText: 'Forbidden',
     });
 
     // When
@@ -97,7 +95,7 @@ describe('analyticsMetricsHandler', () => {
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: 'Mailgun API error: 403 Forbidden'
+      error: 'Mailgun API error: 403 Forbidden',
     });
     expect(result).toEqual(new PromptResponse(expectedResponse).promptResponse);
   });
@@ -106,7 +104,9 @@ describe('analyticsMetricsHandler', () => {
     // Given
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => { throw new Error('Unexpected token'); }
+      json: async () => {
+        throw new Error('Unexpected token');
+      },
     });
 
     // When
@@ -117,17 +117,19 @@ describe('analyticsMetricsHandler', () => {
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: 'Unexpected token'
+      error: 'Unexpected token',
     });
     expect(result).toEqual(new PromptResponse(expectedResponse).promptResponse);
   });
 
   it('returns early on credential fetch error', async () => {
     // Given
-    const promptResponse = new PromptResponse(JSON.stringify({
-      success: false,
-      error: 'Missing API key'
-    }));
+    const promptResponse = new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: 'Missing API key',
+      }),
+    );
     jest.spyOn(mailgunHelper, 'getMailgunApiKey').mockReturnValue(promptResponse);
 
     // When

--- a/tests/tools/email/list-email-events.test.ts
+++ b/tests/tools/email/list-email-events.test.ts
@@ -7,7 +7,7 @@ global.fetch = jest.fn();
 describe('listEmailEventsHandler', () => {
   const mockCredentials = {
     domain: 'example.com',
-    apiKey: 'test-api-key'
+    apiKey: 'test-api-key',
   };
 
   beforeEach(() => {
@@ -29,9 +29,9 @@ describe('listEmailEventsHandler', () => {
               'message-id': 'abc123@example.com',
               from: 'sender@example.com',
               to: 'user@example.com',
-              subject: 'Test Subject'
-            }
-          }
+              subject: 'Test Subject',
+            },
+          },
         },
         {
           id: 'event2',
@@ -43,9 +43,9 @@ describe('listEmailEventsHandler', () => {
               'message-id': 'abc123@example.com',
               from: 'sender@example.com',
               to: 'user@example.com',
-              subject: 'Test Subject'
-            }
-          }
+              subject: 'Test Subject',
+            },
+          },
         },
         {
           id: 'event3',
@@ -55,8 +55,8 @@ describe('listEmailEventsHandler', () => {
           message: {
             headers: {
               'message-id': 'abc123@example.com',
-            }
-          }
+            },
+          },
         },
         {
           id: 'event3',
@@ -66,15 +66,15 @@ describe('listEmailEventsHandler', () => {
           message: {
             headers: {
               'message-id': 'xyz789@example.com',
-            }
-          }
-        }
-      ]
+            },
+          },
+        },
+      ],
     };
 
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => mockResponse
+      json: async () => mockResponse,
     });
 
     // When
@@ -91,15 +91,13 @@ describe('listEmailEventsHandler', () => {
           events: [
             { event: 'accepted', timestamp: '2024-03-09T16:00:00.755Z' },
             { event: 'delivered', timestamp: '2024-03-09T16:01:40.163Z' },
-            { event: 'opened', 'timestamp': '2024-03-09T16:03:20.745Z' }
+            { event: 'opened', timestamp: '2024-03-09T16:03:20.745Z' },
           ],
         },
         {
           message_id: 'xyz789@example.com',
-          events: [
-            { event: 'opened', timestamp: '2024-03-09T16:05:00.859Z' }
-          ],
-        }
+          events: [{ event: 'opened', timestamp: '2024-03-09T16:05:00.859Z' }],
+        },
       ],
       total_count: 4,
     });
@@ -120,8 +118,8 @@ describe('listEmailEventsHandler', () => {
           message: {
             headers: {
               'message-id': 'abc123@example.com',
-            }
-          }
+            },
+          },
         },
         {
           id: 'event3',
@@ -131,15 +129,15 @@ describe('listEmailEventsHandler', () => {
           message: {
             headers: {
               'message-id': 'xyz789@example.com',
-            }
-          }
-        }
-      ]
+            },
+          },
+        },
+      ],
     };
 
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => mockResponse
+      json: async () => mockResponse,
     });
 
     // When
@@ -148,7 +146,7 @@ describe('listEmailEventsHandler', () => {
       event: 'opened',
       limit: 50,
       beginSearchPeriod: '2024-03-09T16:00:00Z',
-      endSearchPeriod: '2024-03-09T17:00:00Z'
+      endSearchPeriod: '2024-03-09T17:00:00Z',
     });
 
     // Then
@@ -156,18 +154,14 @@ describe('listEmailEventsHandler', () => {
       events: [
         {
           message_id: 'abc123@example.com',
-          events: [
-            { 'event': 'opened', 'timestamp': '2024-03-09T16:03:20.745Z' }
-          ],
+          events: [{ event: 'opened', timestamp: '2024-03-09T16:03:20.745Z' }],
         },
         {
           message_id: 'xyz789@example.com',
-          events: [
-            { event: 'opened', timestamp: '2024-03-09T16:05:00.859Z' }
-          ],
+          events: [{ event: 'opened', timestamp: '2024-03-09T16:05:00.859Z' }],
         },
       ],
-      total_count: 2
+      total_count: 2,
     });
 
     expect(result.role).toBe('assistant');
@@ -179,7 +173,7 @@ describe('listEmailEventsHandler', () => {
     (fetch as jest.Mock).mockResolvedValue({
       ok: false,
       status: 403,
-      statusText: 'Forbidden'
+      statusText: 'Forbidden',
     });
 
     // When
@@ -188,7 +182,7 @@ describe('listEmailEventsHandler', () => {
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: 'Mailgun API error: 403 Forbidden'
+      error: 'Mailgun API error: 403 Forbidden',
     });
     expect(result).toEqual(new PromptResponse(expectedResponse).promptResponse);
   });
@@ -197,7 +191,9 @@ describe('listEmailEventsHandler', () => {
     // Given
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => { throw new Error('invalid json'); }
+      json: async () => {
+        throw new Error('invalid json');
+      },
     });
 
     // When
@@ -206,17 +202,19 @@ describe('listEmailEventsHandler', () => {
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: 'invalid json'
+      error: 'invalid json',
     });
     expect(result).toEqual(new PromptResponse(expectedResponse).promptResponse);
   });
 
   it('returns early on credential fetch error', async () => {
     // Given
-    const promptResponse = new PromptResponse(JSON.stringify({
-      success: false,
-      error: 'Missing credentials'
-    }));
+    const promptResponse = new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: 'Missing credentials',
+      }),
+    );
     jest.spyOn(mailgunHelper, 'getMailgunCredentials').mockReturnValue(promptResponse);
 
     // When

--- a/tests/tools/email/list-email-templates.test.ts
+++ b/tests/tools/email/list-email-templates.test.ts
@@ -9,7 +9,7 @@ global.fetch = jest.fn();
 describe('listEmailTemplatesHandler', () => {
   const mockCredentials = {
     domain: 'example.com',
-    apiKey: 'test-api-key'
+    apiKey: 'test-api-key',
   };
 
   beforeEach(() => {
@@ -25,20 +25,20 @@ describe('listEmailTemplatesHandler', () => {
           id: 'template1',
           name: 'my Template 1',
           description: 'The template #1',
-          createdAt: 'Fri, 28 Mar 2025 17:42:30 UTC'
+          createdAt: 'Fri, 28 Mar 2025 17:42:30 UTC',
         },
         {
           id: 'template2',
           name: 'my Template 2',
           description: 'The template #2',
-          createdAt: 'Wed, 26 Mar 2025 11:11:48 UTC'
-        }
-      ]
+          createdAt: 'Wed, 26 Mar 2025 11:11:48 UTC',
+        },
+      ],
     };
 
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => mockResponse
+      json: async () => mockResponse,
     });
 
     // When
@@ -51,17 +51,17 @@ describe('listEmailTemplatesHandler', () => {
           id: 'template1',
           name: 'my Template 1',
           description: 'The template #1',
-          createdAt: '2025-03-28T17:42:30.000Z'
+          createdAt: '2025-03-28T17:42:30.000Z',
         },
         {
           id: 'template2',
           name: 'my Template 2',
           description: 'The template #2',
-          createdAt: '2025-03-26T11:11:48.000Z'
-        }
+          createdAt: '2025-03-26T11:11:48.000Z',
+        },
       ],
-      total_count: 2
-    })
+      total_count: 2,
+    });
 
     expect(result.role).toBe('assistant');
     expect(result.content[0].text).toBe(expectedResponse);
@@ -72,7 +72,7 @@ describe('listEmailTemplatesHandler', () => {
     (fetch as jest.Mock).mockResolvedValue({
       ok: false,
       status: 403,
-      statusText: 'Forbidden'
+      statusText: 'Forbidden',
     });
 
     // When
@@ -81,7 +81,7 @@ describe('listEmailTemplatesHandler', () => {
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: 'Mailgun API error: 403 Forbidden'
+      error: 'Mailgun API error: 403 Forbidden',
     });
     expect(result).toEqual(new PromptResponse(expectedResponse).promptResponse);
   });
@@ -90,7 +90,9 @@ describe('listEmailTemplatesHandler', () => {
     // Given
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => { throw new Error('invalid json'); }
+      json: async () => {
+        throw new Error('invalid json');
+      },
     });
 
     // When
@@ -99,17 +101,19 @@ describe('listEmailTemplatesHandler', () => {
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: 'invalid json'
+      error: 'invalid json',
     });
     expect(result).toEqual(new PromptResponse(expectedResponse).promptResponse);
   });
 
   it('returns early on credential fetch error', async () => {
     // Given
-    const promptResponse = new PromptResponse(JSON.stringify({
-      success: false,
-      error: 'Missing credentials'
-    }));
+    const promptResponse = new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: 'Missing credentials',
+      }),
+    );
     jest.spyOn(mailgunHelper, 'getMailgunCredentials').mockReturnValue(promptResponse);
 
     // When

--- a/tests/tools/email/send-email.test.ts
+++ b/tests/tools/email/send-email.test.ts
@@ -10,14 +10,13 @@ jest.mock('undici', () => ({
     set(key: string, value: string) {
       this.fields[key] = value;
     }
-  }
+  },
 }));
 
 describe('sendEmailHandler', () => {
-
   const mockCredentials = {
     domain: 'example.com',
-    apiKey: 'test-api-key'
+    apiKey: 'test-api-key',
   };
 
   beforeEach(() => {
@@ -31,7 +30,7 @@ describe('sendEmailHandler', () => {
     (fetch as jest.Mock).mockResolvedValue({
       status: 200,
       statusText: 'OK',
-      json: mockJson
+      json: mockJson,
     });
 
     // When
@@ -39,7 +38,7 @@ describe('sendEmailHandler', () => {
       sender: 'sender@example.com',
       recipient: 'user@example.com',
       subject: 'Test Subject',
-      body: '<p>Hello</p>'
+      body: '<p>Hello</p>',
     });
 
     // Then
@@ -47,8 +46,8 @@ describe('sendEmailHandler', () => {
       success: true,
       message_id: '<test-id-123.mailgun.org>',
       recipient: 'user@example.com',
-      subject: 'Test Subject'
-    })
+      subject: 'Test Subject',
+    });
     expect(result.content[0].text).toBe(expectedResponse);
   });
 
@@ -58,7 +57,7 @@ describe('sendEmailHandler', () => {
     (fetch as jest.Mock).mockResolvedValue({
       status: 200,
       statusText: 'OK',
-      json: mockJson
+      json: mockJson,
     });
 
     // When
@@ -67,7 +66,7 @@ describe('sendEmailHandler', () => {
       recipient: 'user@example.com',
       subject: 'Template Subject',
       template: 'welcome-email',
-      templateVariables: { name: 'User' }
+      templateVariables: { name: 'User' },
     });
 
     // Then
@@ -75,7 +74,7 @@ describe('sendEmailHandler', () => {
       success: true,
       message_id: '<template-id-456.mailgun.org>',
       recipient: 'user@example.com',
-      subject: 'Template Subject'
+      subject: 'Template Subject',
     });
     expect(result.content[0].text).toBe(expectedResponse);
   });
@@ -85,13 +84,13 @@ describe('sendEmailHandler', () => {
     const result = await sendEmailHandler({
       sender: 'sender@example.com',
       recipient: 'user@example.com',
-      subject: 'Missing Content'
+      subject: 'Missing Content',
     });
 
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: 'The "body" is not provided and no template name is specified.'
+      error: 'The "body" is not provided and no template name is specified.',
     });
     expect(result.content[0].text).toBe(expectedResponse);
   });
@@ -102,7 +101,7 @@ describe('sendEmailHandler', () => {
       ok: false,
       status: 403,
       statusText: 'Forbidden',
-      text: async () => 'Forbidden'
+      text: async () => 'Forbidden',
     });
 
     // When
@@ -110,23 +109,25 @@ describe('sendEmailHandler', () => {
       sender: 'sender@example.com',
       recipient: 'user@example.com',
       subject: 'Test Subject',
-      body: '<p>Hello</p>'
+      body: '<p>Hello</p>',
     });
 
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: '(403 - Forbidden) An error occurred when sending an email to user@example.com: Forbidden'
+      error: '(403 - Forbidden) An error occurred when sending an email to user@example.com: Forbidden',
     });
     expect(result).toEqual(new PromptResponse(expectedResponse).promptResponse);
   });
 
   it('returns early on credential fetch error', async () => {
     // Given
-    const promptResponse = new PromptResponse(JSON.stringify({
-      success: false,
-      error: 'Missing credentials'
-    }));
+    const promptResponse = new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: 'Missing credentials',
+      }),
+    );
     jest.spyOn(mailgunHelper, 'getMailgunCredentials').mockReturnValue(promptResponse);
 
     // When
@@ -134,11 +135,10 @@ describe('sendEmailHandler', () => {
       sender: 'sender@example.com',
       recipient: 'user@example.com',
       subject: 'Test Subject',
-      body: '<p>Hello</p>'
+      body: '<p>Hello</p>',
     });
 
     // Then
     expect(result).toEqual(promptResponse.promptResponse);
   });
-
 });

--- a/tests/tools/email/utils/mailgun-tools-helper.test.ts
+++ b/tests/tools/email/utils/mailgun-tools-helper.test.ts
@@ -1,7 +1,6 @@
 import { sha256 } from '../../../../src/tools/email/utils/mailgun-tools-helper';
 
 describe('hashing function', () => {
-
   it('should return a valid hash for a given input', () => {
     const input = 'test input';
     const expectedHash = '9dfe6f15d1ab73af898739394fd22fd72a03db01834582f24bb2e1c66c7aaeae';

--- a/tests/tools/numbers/release-rented-number.test.ts
+++ b/tests/tools/numbers/release-rented-number.test.ts
@@ -2,9 +2,13 @@ import { releaseRentedNumberHandler } from '../../../src/tools/numbers/release-r
 import { PromptResponse } from '../../../src/types';
 import * as numbersServiceHelper from '../../../src/tools/numbers/utils/numbers-service-helper';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 const mockNumbersService = {
   release: jest.fn(),
@@ -15,9 +19,7 @@ describe('releaseRentedNumberHandler', () => {
 
   beforeEach(() => {
     jest.restoreAllMocks();
-    jest
-      .spyOn(numbersServiceHelper, 'getNumbersService')
-      .mockReturnValue(mockNumbersService as never);
+    jest.spyOn(numbersServiceHelper, 'getNumbersService').mockReturnValue(mockNumbersService as never);
     jest.clearAllMocks();
     process.env = { ...OLD_ENV };
     process.env.PROJECT_ID = 'test-project';

--- a/tests/tools/numbers/utils/numbers-service-helper.test.ts
+++ b/tests/tools/numbers/utils/numbers-service-helper.test.ts
@@ -4,9 +4,13 @@ import { NumbersService } from '@sinch/numbers';
 import { formatUserAgent } from '../../../../src/utils';
 import { PromptResponse } from '../../../../src/types';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 describe('getNumbersService', () => {
   const OLD_ENV = process.env;
@@ -33,13 +37,11 @@ describe('getNumbersService', () => {
     expect(numbersFetchClient!.apiClientOptions.hostname).toBe(NUMBERS_HOSTNAME);
 
     const userAgentPlugin = numbersFetchClient!.apiClientOptions.requestPlugins?.find(
-      (plugin) => plugin.getName() === 'AdditionalHeadersRequest'
+      (plugin) => plugin.getName() === 'AdditionalHeadersRequest',
     );
     expect(userAgentPlugin).toBeDefined();
     const expectedUserAgent = formatUserAgent(TOOL_NAME, PROJECT_ID);
-    expect(
-      (await (userAgentPlugin as any).additionalHeaders.headers)['User-Agent']
-    ).toBe(expectedUserAgent);
+    expect((await (userAgentPlugin as any).additionalHeaders.headers)['User-Agent']).toBe(expectedUserAgent);
   });
 
   it('returns prompt response when credentials are missing', () => {
@@ -48,8 +50,6 @@ describe('getNumbersService', () => {
     const result = getNumbersService(TOOL_NAME);
 
     expect(result).toBeInstanceOf(PromptResponse);
-    expect((result as PromptResponse).promptResponse.content[0].text).toContain(
-      'Missing env vars'
-    );
+    expect((result as PromptResponse).promptResponse.content[0].text).toContain('Missing env vars');
   });
 });

--- a/tests/tools/verification/number-lookup.test.ts
+++ b/tests/tools/verification/number-lookup.test.ts
@@ -2,9 +2,13 @@ import { numberLookupHandler } from '../../../src/tools/verification/number-look
 import { PromptResponse } from '../../../src/types';
 import { getNumberLookupService } from '../../../src/tools/verification/utils/number-lookup-service-helper';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 jest.mock('../../../src/tools/verification/utils/number-lookup-service-helper');
 
@@ -36,11 +40,11 @@ describe('numberLookupHandler', () => {
         carrier: 'CarrierX',
         type: 'mobile',
         mobileCountryCode: '123',
-        mobileNetworkCode: '456'
+        mobileNetworkCode: '456',
       },
       countryCode: 'US',
       number: '+1234567890',
-      traceId: 'trace-1234'
+      traceId: 'trace-1234',
     });
 
     // When
@@ -55,12 +59,12 @@ describe('numberLookupHandler', () => {
           carrier: 'CarrierX',
           type: 'mobile',
           mobileCountryCode: '123',
-          mobileNetworkCode: '456'
+          mobileNetworkCode: '456',
         },
         countryCode: 'US',
         number: '+1234567890',
-        traceId: 'trace-1234'
-      }
+        traceId: 'trace-1234',
+      },
     });
     expect(result.content[0].text).toEqual(expectedResponse);
   });
@@ -75,9 +79,8 @@ describe('numberLookupHandler', () => {
     // Then
     const expectedResponse = JSON.stringify({
       success: false,
-      error: 'Failed to look up number \'+1234567890\': Unauthorized'
+      error: "Failed to look up number '+1234567890': Unauthorized",
     });
     expect(result).toEqual(new PromptResponse(expectedResponse).promptResponse);
   });
-
 });

--- a/tests/tools/verification/utils/verification-service-helper.test.ts
+++ b/tests/tools/verification/utils/verification-service-helper.test.ts
@@ -3,9 +3,13 @@ import { VerificationService } from '@sinch/verification';
 import { getVerificationService } from '../../../../src/tools/verification/utils/verification-service-helper';
 import { formatUserAgent } from '../../../../src/utils';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 describe('getVerificationService', () => {
   const OLD_ENV = process.env;
@@ -33,10 +37,11 @@ describe('getVerificationService', () => {
     expect(verificationFetchClient!.apiClientOptions.hostname).toBe(expectedHostname);
     expect(verificationFetchClient!.apiClientOptions.requestPlugins?.length).toBe(3);
 
-    const userAgentPlugin = verificationFetchClient!.apiClientOptions.requestPlugins?.find((plugin) => plugin.getName() === 'AdditionalHeadersRequest');
+    const userAgentPlugin = verificationFetchClient!.apiClientOptions.requestPlugins?.find(
+      (plugin) => plugin.getName() === 'AdditionalHeadersRequest',
+    );
     expect(userAgentPlugin).toBeDefined();
     const expectedUserAgent = formatUserAgent(TOOL_NAME, APPLICATION_KEY);
     expect((await (userAgentPlugin as any).additionalHeaders.headers)['User-Agent']).toBe(expectedUserAgent);
   });
-
 });

--- a/tests/tools/voice/utils/voice-service-helper.test.ts
+++ b/tests/tools/voice/utils/voice-service-helper.test.ts
@@ -3,9 +3,13 @@ import { ApiFetchClient } from '@sinch/sdk-client';
 import { VoiceService } from '@sinch/voice';
 import { formatUserAgent } from '../../../../src/utils';
 
-jest.mock('@sinch/sdk-core/package.json', () => ({
-  version: '1.0.0',
-}), { virtual: true });
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
 
 describe('getVoiceService', () => {
   const OLD_ENV = process.env;
@@ -33,10 +37,11 @@ describe('getVoiceService', () => {
     expect(voiceFetchClient!.apiClientOptions.hostname).toBe(expectedHostname);
     expect(voiceFetchClient!.apiClientOptions.requestPlugins?.length).toBe(3);
 
-    const userAgentPlugin = voiceFetchClient!.apiClientOptions.requestPlugins?.find((plugin) => plugin.getName() === 'AdditionalHeadersRequest');
+    const userAgentPlugin = voiceFetchClient!.apiClientOptions.requestPlugins?.find(
+      (plugin) => plugin.getName() === 'AdditionalHeadersRequest',
+    );
     expect(userAgentPlugin).toBeDefined();
     const expectedUserAgent = formatUserAgent(TOOL_NAME, APPLICATION_KEY);
     expect((await (userAgentPlugin as any).additionalHeaders.headers)['User-Agent']).toBe(expectedUserAgent);
   });
-
 });


### PR DESCRIPTION
## Fix ESLint + Prettier integration

- Wired up `eslint-plugin-prettier` correctly
- Removed ESLint formatting rules that duplicated and conflicted with Prettier (`semi`, `quotes`, `indent`, `comma-dangle`, `object-curly-spacing`, `operator-linebreak`, `max-len`) — Prettier is now the sole owner of formatting
- Added `"printWidth": 120` to `.prettierrc` to preserve the previous line-length limit
- Applied `prettier --write` across the codebase to align all files with the unified config