### PR TITLE
fix: fix auth mapping RCS - Conversation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 | **conference-callout**            | Start a voice call to one or more participants and connect them to a shared conference. <br> _Example prompt_: "Call John (+33612345678) and Lisa (+34987654321) and connect them to a conference room." | voice               |
 | **manage-conference-participant** | Mute, unmute, hold, or resume an individual participant in a conference call. <br> _Example prompt_: "Mute the caller with ID xyz789 in the conference."                                                 | voice               |
 | **close-conference**              | End a conference call by disconnecting all the participants using the ID of the conference. <br> _Example prompt_: "End the current conference call with ID abc123."                                     | voice               |
-| **get-call-information**          | Get information about a call using its ID. <br> _Example prompt_: "Get the details of call ID abc123."                                                                                                  | voice, notification |
+| **get-call-information**          | Get information about a call using its ID. <br> _Example prompt_: "Get the details of call ID abc123."                                                                                                   | voice, notification |
 
 ### RCS Sender Tools
 
@@ -81,7 +81,7 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 | **list-rented-numbers**          | List all active (rented) phone numbers for the project. Can filter by region, type, pattern, and capability. <br> _Example prompt_: "Show me all my active phone numbers in the US."                     | numbers |
 | **search-for-available-numbers** | Search for phone numbers available to rent, with filters for region, type, pattern, and capabilities. <br> _Example prompt_: "Find available local numbers in the US that support SMS."                  | numbers |
 | **rent-sinch-virtual-numbers**   | Rent (activate) one or more phone numbers by providing them in E.164 format. <br> _Example prompt_: "Rent the phone number +12025551234."                                                                | numbers |
-| **release-rented-number**        | Release a rented phone number from your project. <br> _Example prompt_: "Release the phone number +12025551234."                                                                                        | numbers |
+| **release-rented-number**        | Release a rented phone number from your project. <br> _Example prompt_: "Release the phone number +12025551234."                                                                                         | numbers |
 
 ### Configuration Tools
 

--- a/src/resources/rcs/rcs-campaign-setup-guide.ts
+++ b/src/resources/rcs/rcs-campaign-setup-guide.ts
@@ -19,10 +19,12 @@ Before configuring an RCS campaign you need:
 ## Integration bridge
 
 The RCS Provisioning API and the Conversation API are connected via two fields returned by the sender:
-- \`authName\` → maps to \`senderId\` in \`set-rcs-channel-on-app\`
-- \`authToken\` → maps to \`bearerToken\` in \`set-rcs-channel-on-app\`
+- sender's \`authName\` → maps to \`senderId\` in \`set-rcs-channel-on-app\`
+- sender's \`authToken\` → maps to \`bearerToken\` in \`set-rcs-channel-on-app\`
 
-Always retrieve \`authName\` and \`authToken\` from \`get-rcs-sender\` before calling \`set-rcs-channel-on-app\`. 
+Do NOT use the sender's plain \`id\` field (the RCS Provisioning API resource ID, e.g. a UUID) for \`senderId\` — it is a different identifier and is not accepted as the claimed identity for the Conversation API channel link. Confirmed by live testing: passing \`id\` as \`senderId\` (even with a correct \`bearerToken\`) makes the RCS channel disappear entirely from the app's channel list within seconds. Passing \`authName\`/\`authToken\` correctly links the channel and test messages are actually delivered to the device.
+
+Always retrieve \`authName\` and \`authToken\` from \`get-rcs-sender\` before calling \`set-rcs-channel-on-app\`.
 
 ## Sender state machine
 
@@ -52,7 +54,7 @@ Use when the user has all brand details, questionnaire answers, countries, and t
 
 1. **list-rcs-senders** — Check if a sender already exists in the target region.
 2. **create-rcs-sender** — Provide \`region\`, \`billingCategory\`, \`useCase\`, and the full \`details\` object (brand, questionnaire, countries, testNumbers) in one call. If complete, sender lands directly in \`IN_TEST\`.
-3. **set-rcs-channel-on-app** — Use \`authName\` and \`authToken\` from the created sender.
+3. **set-rcs-channel-on-app** — Use the sender's \`authName\` (\`senderId\`) and \`authToken\` (\`bearerToken\`). Do not use the sender's \`id\`.
 4. Test messaging via Conversation API with \`channel: RCS\` on test numbers.
 5. **launch-rcs-sender** — No request body. Check launch requirements first (see below).
 6. Once \`LAUNCHED\`, reconnect \`set-rcs-channel-on-app\` on the production app if needed.
@@ -66,7 +68,7 @@ Use when the user does not have all information ready at creation time.
 3. **update-rcs-sender** — Fill brand details, questionnaire sections, and countries via one or more PATCH calls. Pass \`null\` for \`testNumbers\` or \`countries\` to delete those values.
 4. **add-test-numbers-to-rcs-sender** — Accepts an array of E.164 numbers (max 200 total, 20 invites/day).
 5. **get-rcs-sender** — Check \`testNumberStates[]\` and wait until at least one number is \`VERIFIED\` before proceeding. Use \`retry-rcs-test-number-invite\` if a number is stuck in \`PENDING\` or \`UNVERIFIED\`.
-6. **set-rcs-channel-on-app** — Use \`authName\` and \`authToken\` from the sender.
+6. **set-rcs-channel-on-app** — Use the sender's \`authName\` (\`senderId\`) and \`authToken\` (\`bearerToken\`). Do not use the sender's \`id\`.
 7. Test messaging via Conversation API with \`channel: RCS\` on test numbers.
 8. **launch-rcs-sender** — No request body. Check launch requirements first (see below).
 9. Once \`LAUNCHED\`, reconnect \`set-rcs-channel-on-app\` on the production app if needed.
@@ -124,7 +126,7 @@ If the channel is not yet connected or needs updating, call \`set-rcs-channel-on
 
 - **ACTIVE** — Channel is connected and ready. Proceed to test messaging.
 - **PENDING** — Connection in progress. Wait and check again before testing.
-- **FAILING** — Credentials rejected. \`authName\` or \`authToken\` may be wrong or stale. Retrieve fresh values and retry \`set-rcs-channel-on-app\`.
+- **FAILING** (or the channel entry disappearing from the app entirely) — Credentials rejected. Check that \`senderId\` was set from the sender's \`authName\` (not the sender's \`id\`) and that \`bearerToken\` was set from the sender's \`authToken\` (not \`authName\`). Retrieve fresh values and retry \`set-rcs-channel-on-app\`.
 - **UNRECOGNIZED** — Unexpected state, treat as an error.
 
 Do not proceed to test messaging until \`channelStatus\` is \`ACTIVE\`.

--- a/src/tools/conversation/set-rcs-channel-on-app.ts
+++ b/src/tools/conversation/set-rcs-channel-on-app.ts
@@ -10,8 +10,16 @@ import { ConversationAppId, ConversationRegionOverride } from './prompt-schemas'
 
 const SetRcsChannelOnAppSchema = {
   appId: ConversationAppId,
-  senderId: z.string().describe('RCS sender ID.'),
-  bearerToken: z.string().describe('Bearer token for the RCS channel.'),
+  senderId: z
+    .string()
+    .describe(
+      "Claimed identity for the RCS channel — use the `authName` field from get-rcs-sender/create-rcs-sender. Do NOT use the sender's `id`; that is a different identifier and will cause the channel to fail or disappear from the app.",
+    ),
+  bearerToken: z
+    .string()
+    .describe(
+      'Bearer token for the RCS channel — use the `authToken` field from get-rcs-sender/create-rcs-sender. Do NOT use `authName` here; it looks similar but belongs in `senderId`, not `bearerToken`.',
+    ),
   region: ConversationRegionOverride,
 };
 

--- a/src/tools/rcs/get-rcs-sender.ts
+++ b/src/tools/rcs/get-rcs-sender.ts
@@ -25,7 +25,7 @@ export const registerGetRcsSender = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description:
-        'Get an RCS sender by ID. Returns authName and authToken needed for set-rcs-channel-on-app, plus state, details, and countryStatus.',
+        "Get an RCS sender by ID. Returns authName and authToken needed for set-rcs-channel-on-app (as senderId and bearerToken respectively), plus state, details, and countryStatus. Note: the sender's `id` field must NOT be used as senderId in set-rcs-channel-on-app — use authName instead.",
       inputSchema: GetRcsSenderSchema,
     },
     getRcsSenderHandler,

--- a/tests/tools/conversation/set-rcs-channel-on-app.test.ts
+++ b/tests/tools/conversation/set-rcs-channel-on-app.test.ts
@@ -1,0 +1,75 @@
+import { setRcsChannelOnAppHandler } from '../../../src/tools/conversation/set-rcs-channel-on-app';
+import { getConversationService } from '../../../src/tools/conversation/utils/conversation-service-helper';
+
+jest.mock(
+  '@sinch/sdk-core/package.json',
+  () => ({
+    version: '1.0.0',
+  }),
+  { virtual: true },
+);
+
+jest.mock('../../../src/tools/conversation/utils/conversation-service-helper', () => ({
+  getConversationService: jest.fn(),
+  setConversationRegion: jest.fn(() => 'us'),
+}));
+
+const mockGet = jest.fn();
+const mockUpdate = jest.fn();
+const mockConversationService = {
+  app: {
+    get: mockGet,
+    update: mockUpdate,
+  },
+};
+
+(getConversationService as jest.Mock).mockReturnValue(mockConversationService);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('setRcsChannelOnAppHandler merges RCS credentials into the app using senderId and bearerToken as claimed_identity/token', async () => {
+  mockGet.mockResolvedValue({
+    id: 'app-123',
+    channel_credentials: [
+      {
+        channel: 'MESSENGER',
+        static_token: { token: 'fb-token' },
+        state: { status: 'ACTIVE' },
+        channel_known_id: 'page-1',
+      },
+    ],
+  });
+  mockUpdate.mockResolvedValue({
+    id: 'app-123',
+    channel_credentials: [{ channel: 'RCS', state: { status: 'PENDING' } }],
+  });
+
+  // senderId must be the sender's `authName`, and bearerToken must be the sender's `authToken`.
+  const result = await setRcsChannelOnAppHandler({
+    appId: 'app-123',
+    senderId: 'NYrCvmTzGPVwg1zF', // sender's authName
+    bearerToken: 'aAGC9yAqcV60UZhcE2Ejr9zd', // sender's authToken
+  });
+
+  expect(mockUpdate).toHaveBeenCalledWith({
+    app_id: 'app-123',
+    appUpdateRequestBody: {
+      channel_credentials: [
+        {
+          channel: 'MESSENGER',
+          static_token: { token: 'fb-token' },
+        },
+        {
+          channel: 'RCS',
+          static_bearer: {
+            claimed_identity: 'NYrCvmTzGPVwg1zF',
+            token: 'aAGC9yAqcV60UZhcE2Ejr9zd',
+          },
+        },
+      ],
+    },
+  });
+  expect(result.content[0].text).toContain('"success":true');
+});


### PR DESCRIPTION
## Summary
- Fix `senderId`/`bearerToken` mapping in `set-rcs-channel-on-app`: `senderId` must be the sender's `authName`, `bearerToken` must be the sender's `authToken`. The sender's `id` field must never be used — it causes the RCS channel to silently disappear from the app.
- Correct the `sinch://rcs/campaign-setup-guide` resource and `set-rcs-channel-on-app`/`get-rcs-sender` tool descriptions, which previously pointed to the wrong fields.
- Add missing regression test for the RCS channel-link handler.