### PR TITLE
chore: DEVEXP-1515 suppress sonar qube warning for tests

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,11 @@ sonar.sources=src
 sonar.tests=tests
 sonar.exclusions=**/node_modules/**,**/dist/**,coverage/**
 sonar.typescript.tsconfigPath=tsconfig.json
+
+# .int/.eval tests declare cases via a shared harness, not a literal it()/test(),
+# so Sonar can't see them and flags S2187. Ignoring them below
+sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria.e1.ruleKey=typescript:S2187
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.int.test.ts
+sonar.issue.ignore.multicriteria.e2.ruleKey=typescript:S2187
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.eval.test.ts


### PR DESCRIPTION
## Fix SonarQube S2187 false positive on integration/eval test files

`.int.test.ts` and `.eval.test.ts` files register their test cases through a shared harness (`defineWorkflowEval`, `it.each` over fixtures) instead of a literal `it()`/`test()` call. Sonar's static analysis can't trace through that indirection, so it flags these files with `typescript:S2187` ("Add at least one test to this file") even though the tests run and pass in CI.

Added a scoped `sonar.issue.ignore.multicriteria` exclusion in [[sonar-project.properties](https://claude.ai/epitaxy/sonar-project.properties)](sonar-project.properties) that suppresses S2187 specifically for `**/*.int.test.ts` and `**/*.eval.test.ts`, without touching any other rule or file.