### PR TITLE
Devexp 1508 whatsapp create template tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 
 ### WhatsApp Template Tools
 
-| Tool                          | Description                                                                                                                                                                    | Tags     |
-| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| **create-whatsapp-template**  | Create a WhatsApp message template, as a draft or submitted for review. <br> _Example prompt_: "Create a WhatsApp UTILITY template named order_confirmation in English with body text 'Your order {{1}} has shipped.'" | whatsapp |
+| Tool                         | Description                                                                                                                                                                                                            | Tags                    |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| **create-whatsapp-template** | Create a WhatsApp message template, as a draft or submitted for review. <br> _Example prompt_: "Create a WhatsApp UTILITY template named order_confirmation in English with body text 'Your order {{1}} has shipped.'" | whatsapp, configuration |
 
 ### Numbers Tools
 
@@ -329,7 +329,6 @@ You can then configure the MCP server in the Claude configuration file as follow
 
 (Replace the `http://localhost:8000/sse` with the URL of your MCP server if it is not running locally)
 
-
 ## Option 3: Native Streamable HTTP server (recommended for remote)
 
 This option runs a **native Streamable HTTP** MCP server on `/mcp`. Choose **single-tenant** or **multi-tenant** deployment — they are mutually exclusive.
@@ -358,8 +357,8 @@ KEY_SECRET=
 
 Remote clients send **one header** on every request:
 
-| Header | Value |
-|--------|--------|
+| Header          | Value                  |
+| --------------- | ---------------------- |
 | `Authorization` | `Bearer <MCP_API_KEY>` |
 
 `MCP_API_KEY` (or comma-separated `MCP_API_KEYS` for [key rotation](#mcp_api_keys-key-rotation)) authorizes access to the MCP server. `PROJECT_ID`, `KEY_ID`, and `KEY_SECRET` are read from the server environment only — **`X-Sinch-Credentials` is ignored** in this mode (no client override of server credentials).
@@ -370,8 +369,8 @@ Use when different clients must use different Sinch projects. **Do not set `MCP_
 
 Remote clients send **one header** on every request:
 
-| Header | Value |
-|--------|--------|
+| Header                | Value                                      |
+| --------------------- | ------------------------------------------ |
 | `X-Sinch-Credentials` | Base64-encoded `projectId:keyId:keySecret` |
 
 The server does **not** read `PROJECT_ID`, `KEY_ID`, or `KEY_SECRET` from its environment for OAuth-backed tools in this mode. OAuth clients are cached in memory with **LRU eviction** (default 256 entries, configurable via `OAUTH_TOKEN_CACHE_MAX_ENTRIES`).
@@ -447,7 +446,6 @@ Each MCP client session creates an in-memory `McpServer` instance (all registere
 ```
 
 After the `initialize` response, include the `mcp-session-id` header returned by the server on subsequent requests.
-
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 | **get-rcs-test-number-state**     | Get the verification state of a single RCS test number. <br> _Example prompt_: "What is the state of test number +14155552671 on sender abc123?"                                                                                                   | rcs, configuration |
 | **get-rcs-number-capabilities**   | Get the RCS features supported by a test number's device (actions, rich card layouts, revocation). <br> _Example prompt_: "What RCS features does +14155552671 support?"                                                                           | rcs, configuration |
 
+### WhatsApp Template Tools
+
+| Tool                          | Description                                                                                                                                                                    | Tags     |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| **create-whatsapp-template**  | Create a WhatsApp message template, as a draft or submitted for review. <br> _Example prompt_: "Create a WhatsApp UTILITY template named order_confirmation in English with body text 'Your order {{1}} has shipped.'" | whatsapp |
+
 ### Numbers Tools
 
 | Tool                             | Description                                                                                                                                                                                              | Tags    |
@@ -102,6 +108,8 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 To use the APIs used by the MCP tools, you will need the following credentials:
 
 - RCS API credentials: RCS must be enabled for your Sinch project. Contact si-richmessaging@sinch.com to activate it. Once enabled, RCS uses the same `PROJECT_ID`, `KEY_ID`, and `KEY_SECRET` as the Conversation API (see below).
+
+- WhatsApp Template API credentials: uses the same `PROJECT_ID`, `KEY_ID`, and `KEY_SECRET` as the Conversation API (see below).
 
 - Conversation / Numbers API credentials:
   - (Required) `PROJECT_ID`: Select the project you want to use from your [Sinch Build dashboard](https://dashboard.sinch.com/dashboard) (Located at the left of the top toolbar)
@@ -227,7 +235,7 @@ You can combine multiple tags by separating them with commas. For example, if yo
       ],
 ```
 
-Available tags: `conversation`, `rcs`, `email`, `verification`, `voice`, `numbers`, `notification`, `configuration`, `all`.
+Available tags: `conversation`, `rcs`, `whatsapp`, `email`, `verification`, `voice`, `numbers`, `notification`, `configuration`, `all`.
 
 If you want to use all the tools, you can omit the `--tags` option, or use the tag `all`:
 

--- a/src/provisioning-client.ts
+++ b/src/provisioning-client.ts
@@ -12,6 +12,9 @@ export interface ProvisioningErrorBody {
 
 // Base REST client for Sinch provisioning APIs (Basic auth, project-scoped
 // paths). Subclasses set the resource segment and their own ApiError type.
+//
+// RcsProvisioningClient still duplicates this logic rather than extending it —
+// migrating it is deferred to a follow-up PR: https://sinchenterprise.atlassian.net/browse/DEVEXP-1514
 export abstract class BaseProvisioningClient {
   protected constructor(
     private readonly resource: string,

--- a/src/provisioning-client.ts
+++ b/src/provisioning-client.ts
@@ -1,0 +1,65 @@
+import { HttpStatus } from './http-status';
+import { formatUserAgent } from './utils';
+
+const PROVISIONING_HOST = 'https://provisioning.api.sinch.com';
+
+// Shared error-response shape, used to build each client's ApiError via buildApiError().
+export interface ProvisioningErrorBody {
+  errorCode?: string;
+  message?: string;
+  resolution?: string;
+}
+
+// Base REST client for Sinch provisioning APIs (Basic auth, project-scoped
+// paths). Subclasses set the resource segment and their own ApiError type.
+export abstract class BaseProvisioningClient {
+  protected constructor(
+    private readonly resource: string,
+    private readonly projectId: string,
+    private readonly keyId: string,
+    private readonly keySecret: string,
+    private readonly toolName: string,
+  ) {}
+
+  protected abstract buildApiError(status: number, statusText: string, errorCode?: string, resolution?: string): Error;
+
+  private baseUrl(): string {
+    return `${PROVISIONING_HOST}/v1/projects/${this.projectId}/${this.resource}`;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: 'Basic ' + Buffer.from(`${this.keyId}:${this.keySecret}`).toString('base64'),
+      'User-Agent': formatUserAgent(this.toolName, this.projectId),
+    };
+  }
+
+  private async parseError(response: Response): Promise<Error> {
+    let body: ProvisioningErrorBody = {};
+    try {
+      body = (await response.json()) as ProvisioningErrorBody;
+    } catch {
+      // ignore JSON parse errors
+    }
+    return this.buildApiError(response.status, body.message ?? response.statusText, body.errorCode, body.resolution);
+  }
+
+  protected async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const response = await fetch(`${this.baseUrl()}${path}`, {
+      method,
+      headers: this.headers(),
+      ...(body !== undefined && { body: JSON.stringify(body) }),
+    });
+
+    if (!response.ok) {
+      throw await this.parseError(response);
+    }
+
+    if (response.status === HttpStatus.NO_CONTENT) {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { registerVoiceTools } from './tools/voice';
 import { registerEmailTools } from './tools/email';
 import { registerNumbersTools } from './tools/numbers';
 import { registerRcsTools } from './tools/rcs';
+import { registerWhatsAppTools } from './tools/whatsapp';
 import { Tags } from './types';
 import pkg from '../package.json';
 const mcpServerVersion = pkg.version;
@@ -46,4 +47,5 @@ export const registerCapabilities = (server: McpServer, tags: Tags[]) => {
   registerEmailTools(server, tags);
   registerNumbersTools(server, tags);
   registerRcsTools(server, tags);
+  registerWhatsAppTools(server, tags);
 };

--- a/src/tools/whatsapp/create-whatsapp-template.ts
+++ b/src/tools/whatsapp/create-whatsapp-template.ts
@@ -1,0 +1,60 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { registerTracedTool } from '../../telemetry/register-traced-tool';
+import { IPromptResponse, PromptResponse, Tags } from '../../types';
+import { matchesAnyTag } from '../../utils';
+import { CreateWhatsAppTemplateSchema } from './prompt-schemas';
+import { CreateWhatsAppTemplateRequest } from './types/whatsapp-api';
+import { runWhatsAppHandler } from './utils/whatsapp-handler-helper';
+import { getToolName, toolsConfig, WhatsAppToolKey } from './utils/whatsapp-tools-helper';
+
+type CreateWhatsAppTemplate = z.infer<z.ZodObject<typeof CreateWhatsAppTemplateSchema>>;
+
+const TOOL_KEY: WhatsAppToolKey = 'createWhatsAppTemplate';
+const TOOL_NAME = getToolName(TOOL_KEY);
+
+export const registerCreateWhatsAppTemplate = (server: McpServer, tags: Tags[]) => {
+  if (!matchesAnyTag(tags, toolsConfig[TOOL_KEY].tags)) {
+    return;
+  }
+
+  registerTracedTool(
+    server,
+    TOOL_NAME,
+    {
+      description:
+        'Create a WhatsApp message template in the project. Required fields: name, language, category. Provide details.components to define the content — it must include a BODY component. If status is SUBMIT (the default), the template is submitted for review immediately; if DRAFT, it is saved without validation for later editing.',
+      inputSchema: CreateWhatsAppTemplateSchema,
+    },
+    createWhatsAppTemplateHandler,
+  );
+};
+
+export const createWhatsAppTemplateHandler = async ({
+  name,
+  language,
+  category,
+  details,
+  status,
+  saveDraftOnFailure,
+  allowCategoryChange,
+}: CreateWhatsAppTemplate): Promise<IPromptResponse> =>
+  runWhatsAppHandler(TOOL_NAME, async (client) => {
+    const body: CreateWhatsAppTemplateRequest = {
+      name,
+      language,
+      category,
+      ...(details !== undefined && { details }),
+      ...(status !== undefined && { status }),
+      ...(saveDraftOnFailure !== undefined && { saveDraftOnFailure }),
+      ...(allowCategoryChange !== undefined && { allowCategoryChange }),
+    };
+    const template = await client.createTemplate(body);
+
+    return new PromptResponse(
+      JSON.stringify({
+        success: true,
+        template,
+      }),
+    ).promptResponse;
+  });

--- a/src/tools/whatsapp/index.ts
+++ b/src/tools/whatsapp/index.ts
@@ -1,0 +1,7 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Tags } from '../../types';
+import { registerCreateWhatsAppTemplate } from './create-whatsapp-template';
+
+export const registerWhatsAppTools = (server: McpServer, tags: Tags[]) => {
+  registerCreateWhatsAppTemplate(server, tags);
+};

--- a/src/tools/whatsapp/prompt-schemas/index.ts
+++ b/src/tools/whatsapp/prompt-schemas/index.ts
@@ -241,7 +241,7 @@ const WhatsAppButtonsComponent = z.object({
   type: z.literal('BUTTONS'),
   buttons: z
     .array(WhatsAppButton)
-    .refine(uniqueTypeAndText, { message: 'Each button must have a unique type/text combination.' })
+    .refine(uniqueTypeAndText, { message: 'Each card button must have a unique type/text combination.' })
     .optional()
     .describe('Buttons. Not required for draft.'),
 });
@@ -275,7 +275,7 @@ const WhatsAppCardButtonsComponent = z.object({
   type: z.literal('BUTTONS'),
   buttons: z
     .array(WhatsAppCardButton)
-    .refine(uniqueTypeAndText, { message: 'Card buttons must not all share the same type/text combination.' })
+    .refine(uniqueTypeAndText, { message: 'Each card button must have a unique type/text combination.' })
     .optional()
     .describe('Card buttons. Can be a mix of quick reply, phone number, and URL buttons. Not required for draft.'),
 });
@@ -336,9 +336,11 @@ export const WhatsAppTemplateDetails = z
       .number()
       .optional()
       .describe(
-        'Template message delivery retry time-to-live override, in seconds. Defaults and valid ranges depend on category: ' +
-          'AUTHENTICATION defaults to 600 (10 min), range 10-900; MARKETING defaults to 2592000 (30 days), range 43200-2592000; ' +
-          'UTILITY defaults to 2592000 (30 days), range 30-43200. Authentication templates created before 2024-10-23 default to a 30-day TTL.',
+        'Template message delivery retry time-to-live override, in seconds. If unset, the message is retried for the ' +
+          "category's default period before being dropped: AUTHENTICATION 600s (10 min), MARKETING 2592000s (30 days), " +
+          'UTILITY 2592000s (30 days). If overriding, valid ranges differ from the defaults: AUTHENTICATION 10-900 ' +
+          '(10 sec-15 min), MARKETING 43200-2592000 (12 hours-30 days), UTILITY 30-43200 (30 sec-12 hours). ' +
+          'Authentication templates created before 2024-10-23 default to a 30-day TTL.',
       ),
   })
   .optional()

--- a/src/tools/whatsapp/prompt-schemas/index.ts
+++ b/src/tools/whatsapp/prompt-schemas/index.ts
@@ -125,7 +125,7 @@ const WhatsAppMediaHeader = z.object({
 });
 
 const WhatsAppHeaderComponent = z
-  .union([WhatsAppLocationHeader, WhatsAppTextHeader, WhatsAppMediaHeader])
+  .discriminatedUnion('format', [WhatsAppLocationHeader, WhatsAppTextHeader, WhatsAppMediaHeader])
   .describe('Template header. A LOCATION header takes no other fields; TEXT and media formats add their own.');
 
 // ── body / footer components ───────────────────────────────────────────────
@@ -225,7 +225,7 @@ const WhatsAppOtpButton = z.object({
   signatureHash: z.string().optional().describe('Your app signing key hash.'),
 });
 
-const WhatsAppButton = z.union([
+const WhatsAppButton = z.discriminatedUnion('type', [
   WhatsAppFlowButton,
   WhatsAppOtpButton,
   WhatsAppPhoneNumberButton,
@@ -243,9 +243,7 @@ const WhatsAppButtonsComponent = z.object({
     .array(WhatsAppButton)
     .refine(uniqueTypeAndText, { message: 'Each button must have a unique type/text combination.' })
     .optional()
-    .describe(
-      'Buttons. Can only have one entry of each type, except URL, PHONE_NUMBER and QUICK_REPLY. Not required for draft.',
-    ),
+    .describe('Buttons. Not required for draft.'),
 });
 
 // ── carousel ─────────────────────────────────────────────────────────────
@@ -267,7 +265,11 @@ const WhatsAppCardBody = z.object({
     .describe('Examples for the body variables. Requires one example for each variable in the body text.'),
 });
 
-const WhatsAppCardButton = z.union([WhatsAppUrlButton, WhatsAppQuickReplyButton, WhatsAppPhoneNumberButton]);
+const WhatsAppCardButton = z.discriminatedUnion('type', [
+  WhatsAppUrlButton,
+  WhatsAppQuickReplyButton,
+  WhatsAppPhoneNumberButton,
+]);
 
 const WhatsAppCardButtonsComponent = z.object({
   type: z.literal('BUTTONS'),
@@ -278,7 +280,11 @@ const WhatsAppCardButtonsComponent = z.object({
     .describe('Card buttons. Can be a mix of quick reply, phone number, and URL buttons. Not required for draft.'),
 });
 
-const WhatsAppCardComponent = z.union([WhatsAppCardHeader, WhatsAppCardBody, WhatsAppCardButtonsComponent]);
+const WhatsAppCardComponent = z.discriminatedUnion('type', [
+  WhatsAppCardHeader,
+  WhatsAppCardBody,
+  WhatsAppCardButtonsComponent,
+]);
 
 const WhatsAppCard = z.object({
   components: z

--- a/src/tools/whatsapp/prompt-schemas/index.ts
+++ b/src/tools/whatsapp/prompt-schemas/index.ts
@@ -1,0 +1,359 @@
+import { z } from 'zod';
+
+// ── create-whatsapp-template request schema ───────────────────────────────────
+// Mirrors POST /v1/projects/{projectId}/whatsapp/templates exactly — the API
+// rejects unknown fields. Fields required-but-exempt-for-drafts are modelled
+// as optional; the live API enforces that rule, not this schema.
+
+export const WhatsAppTemplateLanguage = z.enum([
+  'AF',
+  'AR',
+  'AZ',
+  'BG',
+  'BN',
+  'CA',
+  'CS',
+  'DA',
+  'DE',
+  'EL',
+  'EN',
+  'EN_GB',
+  'EN_US',
+  'ES',
+  'ES_AR',
+  'ES_ES',
+  'ES_MX',
+  'ES_UY',
+  'ET',
+  'FA',
+  'FI',
+  'FIL',
+  'FR',
+  'GA',
+  'GU',
+  'HA',
+  'HE',
+  'HI',
+  'HR',
+  'HU',
+  'ID',
+  'IT',
+  'JA',
+  'KA',
+  'KK',
+  'KN',
+  'KO',
+  'KY_KG',
+  'LO',
+  'LT',
+  'LV',
+  'MK',
+  'ML',
+  'MR',
+  'MS',
+  'NB',
+  'NL',
+  'PA',
+  'PL',
+  'PT_BR',
+  'PT_PT',
+  'RO',
+  'RU',
+  'RW_RW',
+  'SK',
+  'SL',
+  'SQ',
+  'SR',
+  'SV',
+  'SW',
+  'TA',
+  'TE',
+  'TH',
+  'TR',
+  'UK',
+  'UR',
+  'UZ',
+  'VI',
+  'ZH_CN',
+  'ZH_HK',
+  'ZH_TW',
+  'ZU',
+]);
+
+export const WhatsAppTemplateCategory = z.enum(['AUTHENTICATION', 'MARKETING', 'UTILITY']);
+
+export const WhatsAppTemplateStatus = z.enum(['DRAFT', 'SUBMIT']);
+
+const WhatsAppMediaMimeType = z.enum(['IMAGE/JPEG', 'IMAGE/PNG', 'APPLICATION/PDF', 'VIDEO/3GP', 'VIDEO/MP4']);
+
+const WhatsAppMediaExample = z.object({
+  url: z
+    .string()
+    .optional()
+    .describe(
+      'Uploaded media file URL. Image: 8-bit RGB/RGBA JPEG or PNG, max 5MB. Video: H.264/AAC, single or no audio stream, 3GP or MP4, max 16MB. Document: PDF, max 100MB. Not required for draft.',
+    ),
+  mimeType: WhatsAppMediaMimeType.optional().describe(
+    'Optional mime type of the file if it cannot be determined from the file contents.',
+  ),
+});
+
+// ── header components ───────────────────────────────────────────────────────
+
+const WhatsAppLocationHeader = z.object({
+  type: z.literal('HEADER'),
+  format: z.literal('LOCATION'),
+});
+
+const WhatsAppTextHeader = z.object({
+  type: z.literal('HEADER'),
+  format: z.literal('TEXT'),
+  text: z
+    .string()
+    .optional()
+    .describe('Text to show in the header. Can contain one header variable. Not required for draft.'),
+  example: z
+    .string()
+    .optional()
+    .describe('Example for the header variable. Required if there is a variable in the text header.'),
+});
+
+const WhatsAppMediaHeader = z.object({
+  type: z.literal('HEADER'),
+  format: z.enum(['DOCUMENT', 'IMAGE', 'VIDEO']),
+  example: WhatsAppMediaExample.optional().describe('Header media example. Not required for draft.'),
+});
+
+const WhatsAppHeaderComponent = z
+  .union([WhatsAppLocationHeader, WhatsAppTextHeader, WhatsAppMediaHeader])
+  .describe('Template header. A LOCATION header takes no other fields; TEXT and media formats add their own.');
+
+// ── body / footer components ───────────────────────────────────────────────
+
+const WhatsAppBodyComponent = z.object({
+  type: z.literal('BODY'),
+  text: z.string().optional().describe('Body text. Not required for draft.'),
+  examples: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Examples for the body variables. Requires one example for each variable in the body text. If no variables are used, the examples are optional.',
+    ),
+  addSecurityRecommendation: z
+    .boolean()
+    .optional()
+    .describe(
+      'Only valid if template category is AUTHENTICATION. Adds a security recommendation to the body. Defaults to false.',
+    ),
+});
+
+const WhatsAppFooterComponent = z.object({
+  type: z.literal('FOOTER'),
+  text: z.string().optional(),
+  codeExpirationMinutes: z
+    .number()
+    .optional()
+    .describe(
+      'Only valid if template category is AUTHENTICATION. If set, adds text detailing the code expiration time.',
+    ),
+});
+
+// ── buttons ──────────────────────────────────────────────────────────────
+// Shared shapes, reused unchanged by the carousel card buttons below.
+
+const WhatsAppUrlButton = z.object({
+  type: z.literal('URL'),
+  text: z.string().optional().describe('Not required for draft.'),
+  url: z
+    .string()
+    .optional()
+    .describe(
+      'The url address. To make it dynamic, add {{1}} at the end of the url (e.g. https://www.my-website.com?name={{1}}), not inside the domain. Restricted domains: wa.me, whatsapp.com. Not required for draft.',
+    ),
+  example: z
+    .string()
+    .optional()
+    .describe(
+      'Example of the full url with the dynamic value filled in. Required if the url contains {{1}}, e.g. https://www.my-website.com?name=john.',
+    ),
+});
+
+const WhatsAppQuickReplyButton = z.object({
+  type: z.literal('QUICK_REPLY'),
+  text: z.string().optional().describe('Not required for draft.'),
+});
+
+const WhatsAppPhoneNumberButton = z.object({
+  type: z.literal('PHONE_NUMBER'),
+  text: z.string().optional().describe('Not required for draft.'),
+  phoneNumber: z.string().optional().describe('Not required for draft.'),
+});
+
+const WhatsAppRequestContactInfoButton = z.object({
+  type: z.literal('REQUEST_CONTACT_INFO'),
+});
+
+const WhatsAppFlowButton = z.object({
+  type: z.literal('FLOW'),
+  text: z.string().optional().describe('Text to display on the Flow button. Not required for draft.'),
+  flowId: z.string().optional().describe('Flow ID to launch when the button is pressed. Not required for draft.'),
+  flowAction: z.enum(['DATA_EXCHANGE', 'NAVIGATE']).optional().describe('Not required for draft.'),
+  navigateScreen: z
+    .string()
+    .optional()
+    .describe('The unique ID of the first screen. Required for the Navigate action.'),
+});
+
+const WhatsAppOtpSupportedApp = z.object({
+  packageName: z.string().describe("Your Android app's package name."),
+  signatureHash: z.string().describe('Your app signing key hash.'),
+});
+
+const WhatsAppOtpButton = z.object({
+  type: z.literal('OTP'),
+  otpType: z.enum(['COPY_CODE', 'ONE_TAP', 'ZERO_TAP']),
+  text: z.string().optional().describe('Not required for draft.'),
+  autofillText: z.string().optional().describe('One-tap autofill button label text.'),
+  supportedApps: z.array(WhatsAppOtpSupportedApp).optional().describe('List of supported apps for the OTP button.'),
+  zeroTapTermsAccepted: z
+    .boolean()
+    .optional()
+    .describe(
+      'Set to true to indicate that zero-tap authentication use is subject to the WhatsApp Business Terms of Service, and that it is your responsibility to ensure customers expect the code to be auto-filled when they choose to receive it via WhatsApp.',
+    ),
+  packageName: z.string().optional().describe("Your Android app's package name."),
+  signatureHash: z.string().optional().describe('Your app signing key hash.'),
+});
+
+const WhatsAppButton = z.union([
+  WhatsAppFlowButton,
+  WhatsAppOtpButton,
+  WhatsAppPhoneNumberButton,
+  WhatsAppQuickReplyButton,
+  WhatsAppRequestContactInfoButton,
+  WhatsAppUrlButton,
+]);
+
+const uniqueTypeAndText = (items: Array<{ type: string; text?: string }>) =>
+  new Set(items.map((item) => `${item.type}:${item.text ?? ''}`)).size === items.length;
+
+const WhatsAppButtonsComponent = z.object({
+  type: z.literal('BUTTONS'),
+  buttons: z
+    .array(WhatsAppButton)
+    .refine(uniqueTypeAndText, { message: 'Each button must have a unique type/text combination.' })
+    .optional()
+    .describe(
+      'Buttons. Can only have one entry of each type, except URL, PHONE_NUMBER and QUICK_REPLY. Not required for draft.',
+    ),
+});
+
+// ── carousel ─────────────────────────────────────────────────────────────
+
+const WhatsAppCardHeader = z.object({
+  type: z.literal('HEADER'),
+  format: z.enum(['IMAGE', 'VIDEO']).describe('Card header format.'),
+  example: WhatsAppMediaExample.optional().describe(
+    'Uploaded media asset handle. Media assets are automatically cropped to a wide ratio based on the recipient device. Not required for draft.',
+  ),
+});
+
+const WhatsAppCardBody = z.object({
+  type: z.literal('BODY'),
+  text: z.string().optional().describe('Card body text. Supports variables. Not required for draft.'),
+  examples: z
+    .array(z.string())
+    .optional()
+    .describe('Examples for the body variables. Requires one example for each variable in the body text.'),
+});
+
+const WhatsAppCardButton = z.union([WhatsAppUrlButton, WhatsAppQuickReplyButton, WhatsAppPhoneNumberButton]);
+
+const WhatsAppCardButtonsComponent = z.object({
+  type: z.literal('BUTTONS'),
+  buttons: z
+    .array(WhatsAppCardButton)
+    .refine(uniqueTypeAndText, { message: 'Card buttons must not all share the same type/text combination.' })
+    .optional()
+    .describe('Card buttons. Can be a mix of quick reply, phone number, and URL buttons. Not required for draft.'),
+});
+
+const WhatsAppCardComponent = z.union([WhatsAppCardHeader, WhatsAppCardBody, WhatsAppCardButtonsComponent]);
+
+const WhatsAppCard = z.object({
+  components: z
+    .array(WhatsAppCardComponent)
+    .refine((components) => new Set(components.map((c) => c.type)).size === components.length, {
+      message: 'Each card component type (HEADER, BODY, BUTTONS) may only appear once.',
+    })
+    .optional()
+    .describe(
+      'Components of the card: an image or video header asset, card body text, and up to two buttons. All cards in a template must have the same components. Not required for draft.',
+    ),
+});
+
+const WhatsAppCarouselComponent = z.object({
+  type: z.literal('CAROUSEL'),
+  cards: z
+    .array(WhatsAppCard)
+    .optional()
+    .describe(
+      'Media cards. All cards defined on a template must have the same components. Only two cards need to be defined at creation — an approved template with two cards can send up to 10. Not required for draft.',
+    ),
+});
+
+// ── details ──────────────────────────────────────────────────────────────
+
+const WhatsAppTemplateComponent = z.union([
+  WhatsAppHeaderComponent,
+  WhatsAppBodyComponent,
+  WhatsAppFooterComponent,
+  WhatsAppButtonsComponent,
+  WhatsAppCarouselComponent,
+]);
+
+export const WhatsAppTemplateDetails = z
+  .object({
+    components: z
+      .array(WhatsAppTemplateComponent)
+      .refine((components) => new Set(components.map((c) => c.type)).size === components.length, {
+        message: 'Each component type (HEADER, BODY, FOOTER, BUTTONS, CAROUSEL) may only appear once.',
+      })
+      .refine((components) => components.some((c) => c.type === 'BODY'), {
+        message: 'details.components must include a BODY component.',
+      })
+      .optional()
+      .describe(
+        'List of components in the template. Must contain a BODY component and can only have one entry of each type. Not required for draft.',
+      ),
+    messageSendTtlSeconds: z
+      .number()
+      .optional()
+      .describe(
+        'Template message delivery retry time-to-live override, in seconds. Defaults and valid ranges depend on category: ' +
+          'AUTHENTICATION defaults to 600 (10 min), range 10-900; MARKETING defaults to 2592000 (30 days), range 43200-2592000; ' +
+          'UTILITY defaults to 2592000 (30 days), range 30-43200. Authentication templates created before 2024-10-23 default to a 30-day TTL.',
+      ),
+  })
+  .optional()
+  .describe('Template input details and information. Not required for draft.');
+
+// ── top-level request ──────────────────────────────────────────────────────
+
+export const CreateWhatsAppTemplateSchema = {
+  name: z.string().describe('Template name.'),
+  language: WhatsAppTemplateLanguage.describe('Template language.'),
+  category: WhatsAppTemplateCategory.describe('Template category.'),
+  details: WhatsAppTemplateDetails,
+  status: WhatsAppTemplateStatus.optional().describe('Create as draft or submit for review. Defaults to submit.'),
+  saveDraftOnFailure: z
+    .boolean()
+    .optional()
+    .describe('Save the template as a draft if submission fails. Defaults to false.'),
+  allowCategoryChange: z
+    .boolean()
+    .optional()
+    .describe(
+      'Allow Meta to change the category if they determine it is wrong; if false, Meta might reject the template instead. Defaults to false.',
+    ),
+};

--- a/src/tools/whatsapp/prompt-schemas/index.ts
+++ b/src/tools/whatsapp/prompt-schemas/index.ts
@@ -241,7 +241,7 @@ const WhatsAppButtonsComponent = z.object({
   type: z.literal('BUTTONS'),
   buttons: z
     .array(WhatsAppButton)
-    .refine(uniqueTypeAndText, { message: 'Each card button must have a unique type/text combination.' })
+    .refine(uniqueTypeAndText, { message: 'Each button must have a unique type/text combination.' })
     .optional()
     .describe('Buttons. Not required for draft.'),
 });

--- a/src/tools/whatsapp/types/whatsapp-api.ts
+++ b/src/tools/whatsapp/types/whatsapp-api.ts
@@ -1,0 +1,175 @@
+import { z } from 'zod';
+import {
+  WhatsAppTemplateCategory as WhatsAppTemplateCategorySchema,
+  WhatsAppTemplateLanguage as WhatsAppTemplateLanguageSchema,
+} from '../prompt-schemas';
+
+// Hand-written stand-ins for WhatsApp models @sinch/sdk-core doesn't expose
+// yet. Remove once the SDK adds native template creation support.
+
+// Derived from the Zod schema so accepted values can't drift from it.
+export type WhatsAppTemplateLanguage = z.infer<typeof WhatsAppTemplateLanguageSchema>;
+export type WhatsAppTemplateCategory = z.infer<typeof WhatsAppTemplateCategorySchema>;
+
+export type WhatsAppTemplateStatus = 'DRAFT' | 'SUBMIT';
+
+// ── request ──────────────────────────────────────────────────────────────
+
+export interface WhatsAppMediaExample {
+  url?: string;
+  mimeType?: string;
+}
+
+export type WhatsAppHeaderComponentRequest =
+  | { type: 'HEADER'; format: 'LOCATION' }
+  | { type: 'HEADER'; format: 'TEXT'; text?: string; example?: string }
+  | { type: 'HEADER'; format: 'DOCUMENT' | 'IMAGE' | 'VIDEO'; example?: WhatsAppMediaExample };
+
+export interface WhatsAppBodyComponentRequest {
+  type: 'BODY';
+  text?: string;
+  examples?: string[];
+  addSecurityRecommendation?: boolean;
+}
+
+export interface WhatsAppFooterComponentRequest {
+  type: 'FOOTER';
+  text?: string;
+  codeExpirationMinutes?: number;
+}
+
+export interface WhatsAppOtpSupportedApp {
+  packageName: string;
+  signatureHash: string;
+}
+
+export type WhatsAppButtonRequest =
+  | { type: 'FLOW'; text?: string; flowId?: string; flowAction?: 'DATA_EXCHANGE' | 'NAVIGATE'; navigateScreen?: string }
+  | {
+      type: 'OTP';
+      otpType: 'COPY_CODE' | 'ONE_TAP' | 'ZERO_TAP';
+      text?: string;
+      autofillText?: string;
+      supportedApps?: WhatsAppOtpSupportedApp[];
+      zeroTapTermsAccepted?: boolean;
+      packageName?: string;
+      signatureHash?: string;
+    }
+  | { type: 'PHONE_NUMBER'; text?: string; phoneNumber?: string }
+  | { type: 'QUICK_REPLY'; text?: string }
+  | { type: 'REQUEST_CONTACT_INFO' }
+  | { type: 'URL'; text?: string; url?: string; example?: string };
+
+export interface WhatsAppButtonsComponentRequest {
+  type: 'BUTTONS';
+  buttons?: WhatsAppButtonRequest[];
+}
+
+export type WhatsAppCardButtonRequest = Extract<
+  WhatsAppButtonRequest,
+  { type: 'URL' | 'QUICK_REPLY' | 'PHONE_NUMBER' }
+>;
+
+export type WhatsAppCardComponentRequest =
+  | { type: 'HEADER'; format: 'IMAGE' | 'VIDEO'; example?: WhatsAppMediaExample }
+  | { type: 'BODY'; text?: string; examples?: string[] }
+  | { type: 'BUTTONS'; buttons?: WhatsAppCardButtonRequest[] };
+
+export interface WhatsAppCardRequest {
+  components?: WhatsAppCardComponentRequest[];
+}
+
+export interface WhatsAppCarouselComponentRequest {
+  type: 'CAROUSEL';
+  cards?: WhatsAppCardRequest[];
+}
+
+export type WhatsAppTemplateComponentRequest =
+  | WhatsAppHeaderComponentRequest
+  | WhatsAppBodyComponentRequest
+  | WhatsAppFooterComponentRequest
+  | WhatsAppButtonsComponentRequest
+  | WhatsAppCarouselComponentRequest;
+
+export interface WhatsAppTemplateDetailsRequest {
+  components?: WhatsAppTemplateComponentRequest[];
+  messageSendTtlSeconds?: number;
+}
+
+export interface CreateWhatsAppTemplateRequest {
+  name: string;
+  language: WhatsAppTemplateLanguage;
+  category: WhatsAppTemplateCategory;
+  details?: WhatsAppTemplateDetailsRequest;
+  status?: WhatsAppTemplateStatus;
+  saveDraftOnFailure?: boolean;
+  allowCategoryChange?: boolean;
+}
+
+// ── response ─────────────────────────────────────────────────────────────
+// Nested component/button variants stay Record<string, unknown>, matching
+// how RcsSenderDetails.questionnaire/countryStatus/supplierDetails are typed.
+
+export type WhatsAppTemplateState = 'APPROVED' | 'DISABLED' | 'PAUSED' | 'REJECTED' | string;
+
+export type WhatsAppTemplateRejectionCode =
+  | 'ABUSIVE_CONTENT'
+  | 'INCORRECT_CATEGORY'
+  | 'INVALID_FORMAT'
+  | 'NONE'
+  | 'SCAM'
+  | string;
+
+export type WhatsAppTemplateQualityScore =
+  | 'QUALITY_SCORE_GREEN'
+  | 'QUALITY_SCORE_RED'
+  | 'QUALITY_SCORE_YELLOW'
+  | 'QUALITY_SCORE_UNKNOWN'
+  | string;
+
+export interface WhatsAppTemplateButtonAnalytics {
+  type: 'QUICK_REPLY' | 'UNIQUE_URL' | 'URL' | string;
+  content: string;
+  clicks: number;
+}
+
+export interface WhatsAppTemplateAnalytics {
+  sent: number;
+  delivered: number;
+  read: number;
+  start: string;
+  end: string;
+  buttons: WhatsAppTemplateButtonAnalytics[];
+}
+
+export interface WhatsAppTemplateDetailsResponse {
+  components: Array<Record<string, unknown>>;
+  messageSendTtlSeconds?: number;
+}
+
+export interface WhatsAppTemplateChanges {
+  status: 'DRAFT' | 'IN_PROGRESS' | 'REJECTED';
+  allowCategoryChange?: boolean;
+  details?: WhatsAppTemplateDetailsResponse[];
+}
+
+export interface WhatsAppTemplateResponse {
+  name: string;
+  language: string;
+  category: string;
+  analytics: WhatsAppTemplateAnalytics[];
+  isMetaGenerated: boolean;
+  whatsappId?: string;
+  state?: WhatsAppTemplateState;
+  rejectionCode?: WhatsAppTemplateRejectionCode;
+  qualityScore?: WhatsAppTemplateQualityScore;
+  changes?: WhatsAppTemplateChanges;
+  details?: WhatsAppTemplateDetailsResponse;
+}
+
+export interface WhatsAppApiErrorBody {
+  errorCode?: string;
+  message?: string;
+  resolution?: string;
+  additionalInformation?: Record<string, unknown>;
+}

--- a/src/tools/whatsapp/types/whatsapp-api.ts
+++ b/src/tools/whatsapp/types/whatsapp-api.ts
@@ -166,10 +166,3 @@ export interface WhatsAppTemplateResponse {
   changes?: WhatsAppTemplateChanges;
   details?: WhatsAppTemplateDetailsResponse;
 }
-
-export interface WhatsAppApiErrorBody {
-  errorCode?: string;
-  message?: string;
-  resolution?: string;
-  additionalInformation?: Record<string, unknown>;
-}

--- a/src/tools/whatsapp/utils/whatsapp-error-helper.ts
+++ b/src/tools/whatsapp/utils/whatsapp-error-helper.ts
@@ -1,0 +1,16 @@
+import { WhatsAppApiError } from './whatsapp-provisioning-client';
+
+export const formatWhatsAppError = (error: unknown): string => {
+  if (error instanceof WhatsAppApiError) {
+    const parts = [`HTTP ${error.status}: ${error.message}`];
+    if (error.errorCode) {
+      parts.push(`errorCode=${error.errorCode}`);
+    }
+    if (error.resolution) {
+      parts.push(error.resolution);
+    }
+    return parts.join(' ');
+  }
+
+  return error instanceof Error ? error.message : String(error);
+};

--- a/src/tools/whatsapp/utils/whatsapp-handler-helper.ts
+++ b/src/tools/whatsapp/utils/whatsapp-handler-helper.ts
@@ -1,0 +1,26 @@
+import { IPromptResponse, PromptResponse } from '../../../types';
+import { isPromptResponse } from '../../../utils';
+import { formatWhatsAppError } from './whatsapp-error-helper';
+import { WhatsAppProvisioningClient } from './whatsapp-provisioning-client';
+import { getWhatsAppProvisioningClient } from './whatsapp-service-helper';
+
+export const runWhatsAppHandler = async (
+  toolName: string,
+  fn: (client: WhatsAppProvisioningClient) => Promise<IPromptResponse>,
+): Promise<IPromptResponse> => {
+  const maybeClient = getWhatsAppProvisioningClient(toolName);
+  if (isPromptResponse(maybeClient)) {
+    return maybeClient.promptResponse;
+  }
+
+  try {
+    return await fn(maybeClient);
+  } catch (error) {
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: formatWhatsAppError(error),
+      }),
+    ).promptResponse;
+  }
+};

--- a/src/tools/whatsapp/utils/whatsapp-provisioning-client.ts
+++ b/src/tools/whatsapp/utils/whatsapp-provisioning-client.ts
@@ -1,0 +1,33 @@
+import { BaseProvisioningClient } from '../../../provisioning-client';
+import { CreateWhatsAppTemplateRequest, WhatsAppTemplateResponse } from '../types/whatsapp-api';
+
+export class WhatsAppApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly statusText: string,
+    readonly errorCode?: string,
+    readonly resolution?: string,
+  ) {
+    super(`WhatsApp API error (${status} ${statusText})`);
+    this.name = 'WhatsAppApiError';
+  }
+}
+
+export class WhatsAppProvisioningClient extends BaseProvisioningClient {
+  constructor(projectId: string, keyId: string, keySecret: string, toolName: string) {
+    super('whatsapp', projectId, keyId, keySecret, toolName);
+  }
+
+  protected buildApiError(
+    status: number,
+    statusText: string,
+    errorCode?: string,
+    resolution?: string,
+  ): WhatsAppApiError {
+    return new WhatsAppApiError(status, statusText, errorCode, resolution);
+  }
+
+  createTemplate(body: CreateWhatsAppTemplateRequest): Promise<WhatsAppTemplateResponse> {
+    return this.request<WhatsAppTemplateResponse>('POST', '/templates', body);
+  }
+}

--- a/src/tools/whatsapp/utils/whatsapp-service-helper.ts
+++ b/src/tools/whatsapp/utils/whatsapp-service-helper.ts
@@ -1,0 +1,20 @@
+import { env } from '../../../env';
+import { PromptResponse } from '../../../types';
+import { WhatsAppProvisioningClient } from './whatsapp-provisioning-client';
+
+export const getWhatsAppProvisioningClient = (toolName: string): WhatsAppProvisioningClient | PromptResponse => {
+  const projectId = env.PROJECT_ID;
+  const keyId = env.KEY_ID;
+  const keySecret = env.KEY_SECRET;
+
+  if (!projectId || !keyId || !keySecret) {
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.',
+      }),
+    );
+  }
+
+  return new WhatsAppProvisioningClient(projectId, keyId, keySecret, toolName);
+};

--- a/src/tools/whatsapp/utils/whatsapp-service-helper.ts
+++ b/src/tools/whatsapp/utils/whatsapp-service-helper.ts
@@ -1,20 +1,14 @@
-import { env } from '../../../env';
+import { resolveSinchOAuthCredentials } from '../../../auth/resolve-sinch-oauth-credentials';
 import { PromptResponse } from '../../../types';
+import { isPromptResponse } from '../../../utils';
 import { WhatsAppProvisioningClient } from './whatsapp-provisioning-client';
 
 export const getWhatsAppProvisioningClient = (toolName: string): WhatsAppProvisioningClient | PromptResponse => {
-  const projectId = env.PROJECT_ID;
-  const keyId = env.KEY_ID;
-  const keySecret = env.KEY_SECRET;
-
-  if (!projectId || !keyId || !keySecret) {
-    return new PromptResponse(
-      JSON.stringify({
-        success: false,
-        error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.',
-      }),
-    );
+  const maybeCredentials = resolveSinchOAuthCredentials();
+  if (isPromptResponse(maybeCredentials)) {
+    return maybeCredentials;
   }
+  const { projectId, keyId, keySecret } = maybeCredentials;
 
   return new WhatsAppProvisioningClient(projectId, keyId, keySecret, toolName);
 };

--- a/src/tools/whatsapp/utils/whatsapp-tools-helper.ts
+++ b/src/tools/whatsapp/utils/whatsapp-tools-helper.ts
@@ -1,0 +1,14 @@
+import { ToolsConfig } from '../../../types';
+
+const defineToolsConfig = <T extends Record<string, ToolsConfig>>(config: T) => config;
+
+export const toolsConfig = defineToolsConfig({
+  createWhatsAppTemplate: {
+    name: 'create-whatsapp-template',
+    tags: ['all', 'whatsapp', 'create-whatsapp-template'],
+  },
+});
+
+export type WhatsAppToolKey = keyof typeof toolsConfig;
+
+export const getToolName = (toolKey: WhatsAppToolKey): string => toolsConfig[toolKey].name;

--- a/src/tools/whatsapp/utils/whatsapp-tools-helper.ts
+++ b/src/tools/whatsapp/utils/whatsapp-tools-helper.ts
@@ -5,7 +5,7 @@ const defineToolsConfig = <T extends Record<string, ToolsConfig>>(config: T) => 
 export const toolsConfig = defineToolsConfig({
   createWhatsAppTemplate: {
     name: 'create-whatsapp-template',
-    tags: ['all', 'whatsapp', 'create-whatsapp-template'],
+    tags: ['all', 'whatsapp', 'configuration', 'create-whatsapp-template'],
   },
 });
 

--- a/tests/fixtures/server/tag-filtering/all.json
+++ b/tests/fixtures/server/tag-filtering/all.json
@@ -45,7 +45,8 @@
     "resend-rcs-test-number-invite",
     "get-rcs-number-capabilities",
     "get-rcs-test-number-state",
-    "launch-rcs-sender"
+    "launch-rcs-sender",
+    "create-whatsapp-template"
   ],
   "expectedPrompts": [
     "conversation-app-id"

--- a/tests/fixtures/server/tag-filtering/configuration.json
+++ b/tests/fixtures/server/tag-filtering/configuration.json
@@ -19,7 +19,8 @@
     "resend-rcs-test-number-invite",
     "get-rcs-number-capabilities",
     "get-rcs-test-number-state",
-    "launch-rcs-sender"
+    "launch-rcs-sender",
+    "create-whatsapp-template"
   ],
   "expectedPrompts": []
 }

--- a/tests/fixtures/server/tag-filtering/whatsapp.json
+++ b/tests/fixtures/server/tag-filtering/whatsapp.json
@@ -1,0 +1,5 @@
+{
+  "tag": "whatsapp",
+  "expectedTools": ["create-whatsapp-template"],
+  "expectedPrompts": []
+}

--- a/tests/tools/whatsapp/create-whatsapp-template.test.ts
+++ b/tests/tools/whatsapp/create-whatsapp-template.test.ts
@@ -1,0 +1,92 @@
+import { createWhatsAppTemplateHandler } from '../../../src/tools/whatsapp/create-whatsapp-template';
+import { getWhatsAppProvisioningClient } from '../../../src/tools/whatsapp/utils/whatsapp-service-helper';
+import { WhatsAppApiError } from '../../../src/tools/whatsapp/utils/whatsapp-provisioning-client';
+import { PromptResponse } from '../../../src/types';
+
+jest.mock('../../../src/tools/whatsapp/utils/whatsapp-service-helper');
+
+const mockClient = {
+  createTemplate: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getWhatsAppProvisioningClient as jest.Mock).mockReturnValue(mockClient);
+});
+
+test('createWhatsAppTemplateHandler sends the built body and returns the template on success', async () => {
+  mockClient.createTemplate.mockResolvedValue({
+    name: 'order_confirmation',
+    language: 'EN',
+    category: 'UTILITY',
+    analytics: [],
+    isMetaGenerated: false,
+  });
+
+  const details = {
+    components: [{ type: 'BODY' as const, text: 'Your order {{1}} has shipped.', examples: ['12345'] }],
+  };
+
+  const result = await createWhatsAppTemplateHandler({
+    name: 'order_confirmation',
+    language: 'EN',
+    category: 'UTILITY',
+    details,
+    status: 'SUBMIT',
+  });
+  const parsed = JSON.parse(result.content[0].text);
+
+  expect(mockClient.createTemplate).toHaveBeenCalledWith({
+    name: 'order_confirmation',
+    language: 'EN',
+    category: 'UTILITY',
+    details,
+    status: 'SUBMIT',
+  });
+  expect(parsed).toEqual({
+    success: true,
+    template: {
+      name: 'order_confirmation',
+      language: 'EN',
+      category: 'UTILITY',
+      analytics: [],
+      isMetaGenerated: false,
+    },
+  });
+});
+
+test('createWhatsAppTemplateHandler surfaces a WhatsAppApiError as a formatted failure', async () => {
+  mockClient.createTemplate.mockRejectedValue(
+    new WhatsAppApiError(409, 'Conflict', 'template_exists', 'Templates must have unique name and language.'),
+  );
+
+  const result = await createWhatsAppTemplateHandler({
+    name: 'order_confirmation',
+    language: 'EN',
+    category: 'UTILITY',
+  });
+  const parsed = JSON.parse(result.content[0].text);
+
+  expect(parsed).toEqual({
+    success: false,
+    error:
+      'HTTP 409: WhatsApp API error (409 Conflict) errorCode=template_exists Templates must have unique name and language.',
+  });
+});
+
+test('createWhatsAppTemplateHandler returns the guard response when credentials are missing', async () => {
+  const guard = new PromptResponse(
+    JSON.stringify({ success: false, error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.' }),
+  );
+  (getWhatsAppProvisioningClient as jest.Mock).mockReturnValue(guard);
+
+  const result = await createWhatsAppTemplateHandler({
+    name: 'order_confirmation',
+    language: 'EN',
+    category: 'UTILITY',
+  });
+  const parsed = JSON.parse(result.content[0].text);
+
+  expect(parsed).toEqual({ success: false, error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.' });
+  expect(mockClient.createTemplate).not.toHaveBeenCalled();
+});

--- a/tests/tools/whatsapp/create-whatsapp-template.test.ts
+++ b/tests/tools/whatsapp/create-whatsapp-template.test.ts
@@ -1,21 +1,25 @@
 import { createWhatsAppTemplateHandler } from '../../../src/tools/whatsapp/create-whatsapp-template';
 import { getWhatsAppProvisioningClient } from '../../../src/tools/whatsapp/utils/whatsapp-service-helper';
-import { WhatsAppApiError } from '../../../src/tools/whatsapp/utils/whatsapp-provisioning-client';
+import {
+  WhatsAppApiError,
+  WhatsAppProvisioningClient,
+} from '../../../src/tools/whatsapp/utils/whatsapp-provisioning-client';
 import { PromptResponse } from '../../../src/types';
 
 jest.mock('../../../src/tools/whatsapp/utils/whatsapp-service-helper');
 
-const mockClient = {
-  createTemplate: jest.fn(),
-};
+const mockClient = new WhatsAppProvisioningClient('project-id', 'key-id', 'key-secret', 'test-tool');
+const mockCreateTemplate = jest.spyOn(mockClient, 'createTemplate');
+
+const mockedGetClient = jest.mocked(getWhatsAppProvisioningClient);
 
 beforeEach(() => {
   jest.clearAllMocks();
-  (getWhatsAppProvisioningClient as jest.Mock).mockReturnValue(mockClient);
+  mockedGetClient.mockReturnValue(mockClient);
 });
 
 test('createWhatsAppTemplateHandler sends the built body and returns the template on success', async () => {
-  mockClient.createTemplate.mockResolvedValue({
+  mockCreateTemplate.mockResolvedValue({
     name: 'order_confirmation',
     language: 'EN',
     category: 'UTILITY',
@@ -36,7 +40,7 @@ test('createWhatsAppTemplateHandler sends the built body and returns the templat
   });
   const parsed = JSON.parse(result.content[0].text);
 
-  expect(mockClient.createTemplate).toHaveBeenCalledWith({
+  expect(mockCreateTemplate).toHaveBeenCalledWith({
     name: 'order_confirmation',
     language: 'EN',
     category: 'UTILITY',
@@ -56,7 +60,7 @@ test('createWhatsAppTemplateHandler sends the built body and returns the templat
 });
 
 test('createWhatsAppTemplateHandler surfaces a WhatsAppApiError as a formatted failure', async () => {
-  mockClient.createTemplate.mockRejectedValue(
+  mockCreateTemplate.mockRejectedValue(
     new WhatsAppApiError(409, 'Conflict', 'template_exists', 'Templates must have unique name and language.'),
   );
 
@@ -78,7 +82,7 @@ test('createWhatsAppTemplateHandler returns the guard response when credentials 
   const guard = new PromptResponse(
     JSON.stringify({ success: false, error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.' }),
   );
-  (getWhatsAppProvisioningClient as jest.Mock).mockReturnValue(guard);
+  mockedGetClient.mockReturnValue(guard);
 
   const result = await createWhatsAppTemplateHandler({
     name: 'order_confirmation',
@@ -88,5 +92,5 @@ test('createWhatsAppTemplateHandler returns the guard response when credentials 
   const parsed = JSON.parse(result.content[0].text);
 
   expect(parsed).toEqual({ success: false, error: 'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.' });
-  expect(mockClient.createTemplate).not.toHaveBeenCalled();
+  expect(mockCreateTemplate).not.toHaveBeenCalled();
 });

--- a/tests/tools/whatsapp/prompt-schemas.test.ts
+++ b/tests/tools/whatsapp/prompt-schemas.test.ts
@@ -1,0 +1,70 @@
+import { WhatsAppTemplateDetails } from '../../../src/tools/whatsapp/prompt-schemas';
+
+const bodyComponent = { type: 'BODY' as const, text: 'Hello' };
+
+describe('WhatsAppTemplateDetails buttons validation', () => {
+  test('allows two FLOW buttons as long as their type/text combination is unique', () => {
+    const result = WhatsAppTemplateDetails.safeParse({
+      components: [
+        bodyComponent,
+        {
+          type: 'BUTTONS',
+          buttons: [
+            { type: 'FLOW', text: 'Start', flowId: 'flow-1' },
+            { type: 'FLOW', text: 'Restart', flowId: 'flow-2' },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBeTrue();
+  });
+
+  test('rejects two REQUEST_CONTACT_INFO buttons (identical type/text combination)', () => {
+    const result = WhatsAppTemplateDetails.safeParse({
+      components: [
+        bodyComponent,
+        {
+          type: 'BUTTONS',
+          buttons: [{ type: 'REQUEST_CONTACT_INFO' }, { type: 'REQUEST_CONTACT_INFO' }],
+        },
+      ],
+    });
+
+    expect(result.success).toBeFalse();
+  });
+
+  test('allows multiple URL buttons as long as their type/text combination is unique', () => {
+    const result = WhatsAppTemplateDetails.safeParse({
+      components: [
+        bodyComponent,
+        {
+          type: 'BUTTONS',
+          buttons: [
+            { type: 'URL', text: 'Visit A', url: 'https://a.example.com' },
+            { type: 'URL', text: 'Visit B', url: 'https://b.example.com' },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBeTrue();
+  });
+
+  test('rejects two URL buttons with the same text', () => {
+    const result = WhatsAppTemplateDetails.safeParse({
+      components: [
+        bodyComponent,
+        {
+          type: 'BUTTONS',
+          buttons: [
+            { type: 'URL', text: 'Visit', url: 'https://a.example.com' },
+            { type: 'URL', text: 'Visit', url: 'https://b.example.com' },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBeFalse();
+  });
+});

--- a/tests/tools/whatsapp/utils/whatsapp-service-helper.test.ts
+++ b/tests/tools/whatsapp/utils/whatsapp-service-helper.test.ts
@@ -1,0 +1,32 @@
+import { getWhatsAppProvisioningClient } from '../../../../src/tools/whatsapp/utils/whatsapp-service-helper';
+import { WhatsAppProvisioningClient } from '../../../../src/tools/whatsapp/utils/whatsapp-provisioning-client';
+import { PromptResponse } from '../../../../src/types';
+import { mockEnv, resetMockEnv } from '../../../helpers/mock-env';
+
+describe('getWhatsAppProvisioningClient', () => {
+  const TOOL_NAME = 'create-whatsapp-template';
+
+  beforeEach(() => {
+    resetMockEnv();
+    mockEnv.PROJECT_ID = 'test-project';
+    mockEnv.KEY_ID = 'test-key-id';
+    mockEnv.KEY_SECRET = 'test-secret';
+  });
+
+  test('returns a configured WhatsAppProvisioningClient when credentials are present', () => {
+    const client = getWhatsAppProvisioningClient(TOOL_NAME);
+
+    expect(client).toBeInstanceOf(WhatsAppProvisioningClient);
+  });
+
+  test('returns a prompt response when credentials are missing', () => {
+    mockEnv.PROJECT_ID = undefined;
+
+    const result = getWhatsAppProvisioningClient(TOOL_NAME);
+
+    expect(result).toBeInstanceOf(PromptResponse);
+    expect((result as PromptResponse).promptResponse.content[0].text).toContain(
+      'Missing env vars: PROJECT_ID, KEY_ID, KEY_SECRET.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `create-whatsapp-template` tool to create WhatsApp message templates, as draft or submitted for review
- Model the full template schema (header, body, footer, buttons, carousel) with Zod, matching the WhatsApp Template API
- Add a provisioning client for the WhatsApp templates endpoint, following the same structure as the RCS module
- Leave `RcsProvisioningClient` on its old implementation for now, tracked separately in [DEVEXP-1514](https://sinchenterprise.atlassian.net/browse/DEVEXP-1514)

[DEVEXP-1514]: https://sinchenterprise.atlassian.net/browse/DEVEXP-1514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ