### PR TITLE
fix: shorten number-lookup tool description

### DIFF
--- a/src/tools/verification/number-lookup.ts
+++ b/src/tools/verification/number-lookup.ts
@@ -24,8 +24,7 @@ export const registerNumberLookup = (server: McpServer, tags: Tags[]) => {
     server,
     TOOL_NAME,
     {
-      description:
-        'With quick and easy access to Number Lookup, you can enhance your communications and keep your database as clean as a whistle. Number Lookup checks against first-party numbering sources and provides real-time feedback. Test numbers to ensure your recipients are ready and waiting to receive your messages!',
+      description: 'Look up a phone number for its status and capabilities.',
       inputSchema: NumberLookupSchema,
     },
     numberLookupHandler,

--- a/tests/integration/llms/fixtures/tool-cases.ts
+++ b/tests/integration/llms/fixtures/tool-cases.ts
@@ -151,6 +151,11 @@ const verificationCases: ToolTestCase[] = [
     expectedArguments: { phoneNumber: '+33612345678' },
   },
   {
+    prompt: 'Look up the status and capabilities of phone number +33612345678',
+    expectedToolName: 'number-lookup',
+    expectedArguments: { phoneNumber: '+33612345678' },
+  },
+  {
     prompt: 'Verify the phone number +33612345678',
     expectedToolName: 'start-sms-verification',
     expectedArguments: { phoneNumber: '+33612345678' },

--- a/tests/integration/llms/fixtures/tool-cases.ts
+++ b/tests/integration/llms/fixtures/tool-cases.ts
@@ -151,7 +151,7 @@ const verificationCases: ToolTestCase[] = [
     expectedArguments: { phoneNumber: '+33612345678' },
   },
   {
-    prompt: 'Look up the status and capabilities of phone number +33612345678',
+    prompt: 'Look up the status of phone number +33612345678',
     expectedToolName: 'number-lookup',
     expectedArguments: { phoneNumber: '+33612345678' },
   },


### PR DESCRIPTION
Remove marketing copy so the MCP tool description matches the concise style of other tools.