### PR TITLE
Expand LLM tool-selection coverage with ambiguity cases and agentic descriptions.

### DIFF
--- a/src/tools/conversation/delete-webhook.ts
+++ b/src/tools/conversation/delete-webhook.ts
@@ -17,7 +17,8 @@ export const registerDeleteWebhook = (server: McpServer, tags: Tags[]) => {
   server.registerTool(
     TOOL_NAME,
     {
-      description: 'Delete a Conversation API webhook by its ID.',
+      description:
+        'Permanently delete a Conversation API webhook by its ID. Ask for the webhook ID if missing. Prefer update-webhook to clear triggers if the user only wants to disable events.',
       inputSchema: {
         webhookId: WebhookId,
         region: ConversationRegionOverride,

--- a/src/tools/conversation/get-webhook.ts
+++ b/src/tools/conversation/get-webhook.ts
@@ -19,7 +19,7 @@ export const registerGetWebhook = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description:
-        'Get a Conversation API webhook by its ID. Signing secrets are not returned; configure them in the Sinch Dashboard.',
+        'Get a Conversation API webhook by its ID (target URL, triggers, etc.). Signing secrets are not returned — configure them in the Sinch Dashboard. Use list-webhooks to discover IDs first if unknown.',
       inputSchema: {
         webhookId: WebhookId,
         region: ConversationRegionOverride,

--- a/src/tools/conversation/get-webhook.ts
+++ b/src/tools/conversation/get-webhook.ts
@@ -19,7 +19,7 @@ export const registerGetWebhook = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description:
-        'Get a single Conversation API webhook by webhook ID. Signing secrets are not returned — configure them in the Sinch Dashboard. Ask for the webhook ID if missing. Use list-webhooks to browse webhooks when the user does not have an ID yet.',
+        'Get a Conversation API webhook by its ID. Signing secrets are not returned — configure them in the Sinch Dashboard.',
       inputSchema: {
         webhookId: WebhookId,
         region: ConversationRegionOverride,

--- a/src/tools/conversation/get-webhook.ts
+++ b/src/tools/conversation/get-webhook.ts
@@ -19,7 +19,7 @@ export const registerGetWebhook = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description:
-        'Get a Conversation API webhook by its ID. Signing secrets are not returned — configure them in the Sinch Dashboard.',
+        'Get a Conversation API webhook by its ID. Signing secrets are not returned — configure them in the Sinch Dashboard. Use list-webhooks to browse webhooks when the user does not have an ID yet.',
       inputSchema: {
         webhookId: WebhookId,
         region: ConversationRegionOverride,

--- a/src/tools/conversation/get-webhook.ts
+++ b/src/tools/conversation/get-webhook.ts
@@ -19,7 +19,7 @@ export const registerGetWebhook = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description:
-        'Get a Conversation API webhook by its ID (target URL, triggers, etc.). Signing secrets are not returned — configure them in the Sinch Dashboard. Use list-webhooks to discover IDs first if unknown.',
+        'Get a single Conversation API webhook by webhook ID. Signing secrets are not returned — configure them in the Sinch Dashboard. Ask for the webhook ID if missing. Use list-webhooks to browse webhooks when the user does not have an ID yet.',
       inputSchema: {
         webhookId: WebhookId,
         region: ConversationRegionOverride,

--- a/src/tools/numbers/list-available-regions.ts
+++ b/src/tools/numbers/list-available-regions.ts
@@ -27,7 +27,8 @@ export const registerListAvailableRegions = (server: McpServer, tags: Tags[]) =>
     server,
     TOOL_NAME,
     {
-      description: 'Lists all regions for numbers provided for the project ID.',
+      description:
+        'List countries/regions where Sinch virtual numbers are available to search and rent. Use when the user asks where they can buy numbers or which regions are offered. Optional filter by number types (MOBILE, LOCAL, TOLL_FREE). After picking a region, use search-for-available-numbers to find candidates.',
       inputSchema: ListAvailableRegionsSchema,
     },
     listAvailableRegionsHandler,

--- a/src/tools/numbers/list-available-regions.ts
+++ b/src/tools/numbers/list-available-regions.ts
@@ -28,7 +28,7 @@ export const registerListAvailableRegions = (server: McpServer, tags: Tags[]) =>
     TOOL_NAME,
     {
       description:
-        'List countries/regions where Sinch virtual numbers are available to search and rent. Use when the user asks where they can buy numbers or which regions are offered. Optional filter by number types (MOBILE, LOCAL, TOLL_FREE). After picking a region, use search-for-available-numbers to find candidates.',
+        'List countries/regions where Sinch virtual numbers are available to search and rent. Use when the user asks where they can buy numbers or which regions are offered. Optional filter by number types (MOBILE, LOCAL, TOLL_FREE). If the user later wants to find candidates in a region, they can follow up with search-for-available-numbers.',
       inputSchema: ListAvailableRegionsSchema,
     },
     listAvailableRegionsHandler,

--- a/src/tools/numbers/list-rented-numbers.ts
+++ b/src/tools/numbers/list-rented-numbers.ts
@@ -46,7 +46,8 @@ export const registerListRentedNumbers = (server: McpServer, tags: Tags[]) => {
     server,
     TOOL_NAME,
     {
-      description: 'Lists all active numbers for a project.',
+      description:
+        'List phone numbers already rented/active on this project. Optional filters: region, type, digit pattern, SMS/VOICE capability. Use this to see what you own — not to find numbers still available to buy (use search-for-available-numbers) and not to look up carrier/line type for an arbitrary number (use number-lookup).',
       inputSchema: ListRentedNumbersSchema,
     },
     listRentedNumbersHandler,

--- a/src/tools/numbers/release-rented-number.ts
+++ b/src/tools/numbers/release-rented-number.ts
@@ -24,7 +24,8 @@ export const registerReleaseRentedNumber = (server: McpServer, tags: Tags[]) => 
     server,
     TOOL_NAME,
     {
-      description: 'Releases a rented phone number from your project.',
+      description:
+        'Release (cancel) a rented virtual phone number from the project. Requires the exact E.164 phone number. Ask for the number if missing. This is not for searching or renting numbers.',
       inputSchema: ReleaseRentedNumberSchema,
     },
     releaseRentedNumberHandler,

--- a/src/tools/numbers/rent-numbers.ts
+++ b/src/tools/numbers/rent-numbers.ts
@@ -28,7 +28,7 @@ export const registerRentNumbers = (server: McpServer, tags: Tags[]) => {
     TOOL_NAME,
     {
       description:
-        'Activates a phone number that matches the search criteria provided in the request. Currently the rentAny operation works only for US LOCAL numbers',
+        'Rent (activate) one or more known Sinch virtual phone numbers on the project. Requires specific E.164 numbers (with leading +) that the user already chose — typically after search-for-available-numbers. Do NOT invent phone numbers. Do NOT use this to search or browse available numbers — use search-for-available-numbers for that. If the user has not provided an exact number, ask for it or search first.',
       inputSchema: RentNumbersSchema,
     },
     rentNumbersHandler,

--- a/src/tools/numbers/search-for-available-numbers.ts
+++ b/src/tools/numbers/search-for-available-numbers.ts
@@ -47,7 +47,7 @@ export const registerSearchAvailableNumbers = (server: McpServer, tags: Tags[]) 
     TOOL_NAME,
     {
       description:
-        'Search for available Sinch virtual phone numbers you can rent later. Use this when the user wants to find or browse numbers (by country/region, type LOCAL/MOBILE/TOLL_FREE, area-code pattern, or SMS/VOICE capability) but has not yet chosen a specific E.164 number to activate. Do NOT use this to activate/rent a known number — use rent-sinch-virtual-numbers for that. If the user asks vaguely for "a support line" or "a number" without region/type, ask for country/region (and optionally area code or capabilities) before calling, or call this tool once those filters are clear.',
+        'Search for available Sinch virtual phone numbers you can rent (activate) later. Use this when the user wants to find or browse numbers (by country/region, type LOCAL/MOBILE/TOLL_FREE, area-code pattern, or SMS/VOICE capability) but has not yet chosen a specific E.164 number to activate. Do NOT use this to activate/rent a known number — use rent-sinch-virtual-numbers for that. If the user asks vaguely for "a support line" or "a number" without region/type, ask for country/region (and optionally area code or capabilities) before calling, or call this tool once those filters are clear.',
       inputSchema: SearchAvailableNumbersSchema,
     },
     searchAvailableNumbersHandler,

--- a/src/tools/numbers/search-for-available-numbers.ts
+++ b/src/tools/numbers/search-for-available-numbers.ts
@@ -47,7 +47,7 @@ export const registerSearchAvailableNumbers = (server: McpServer, tags: Tags[]) 
     TOOL_NAME,
     {
       description:
-        'Search for available phone numbers that are available for you to activate. You can filter by any property on the available number resource.',
+        'Search for available Sinch virtual phone numbers you can rent later. Use this when the user wants to find or browse numbers (by country/region, type LOCAL/MOBILE/TOLL_FREE, area-code pattern, or SMS/VOICE capability) but has not yet chosen a specific E.164 number to activate. Do NOT use this to activate/rent a known number — use rent-sinch-virtual-numbers for that. If the user asks vaguely for "a support line" or "a number" without region/type, ask for country/region (and optionally area code or capabilities) before calling, or call this tool once those filters are clear.',
       inputSchema: SearchAvailableNumbersSchema,
     },
     searchAvailableNumbersHandler,

--- a/src/tools/rcs/get-rcs-number-capabilities.ts
+++ b/src/tools/rcs/get-rcs-number-capabilities.ts
@@ -25,7 +25,7 @@ export const registerGetRcsNumberCapabilities = (server: McpServer, tags: Tags[]
     TOOL_NAME,
     {
       description:
-        'Return RCS features supported by a specific RCS *test number* device for a given RCS sender (supported actions, rich card layouts, revocation). Requires senderId and the test phone number. Use when the user asks whether a tester can receive RCS / which RCS features their device supports. Do NOT use number-lookup for this — that checks carrier/line type, not RCS client capabilities.',
+        'Return RCS features supported by a specific RCS test number device registered on a given RCS agent (supported actions, rich card layouts, revocation). Requires senderId and the test phone number. Use when the user asks whether a tester can receive RCS / which RCS features their device supports. Do NOT use number-lookup for this — that checks carrier/line type, not RCS client capabilities.',
       inputSchema: GetRcsNumberCapabilitiesSchema,
     },
     getRcsNumberCapabilitiesHandler,

--- a/src/tools/rcs/get-rcs-number-capabilities.ts
+++ b/src/tools/rcs/get-rcs-number-capabilities.ts
@@ -25,8 +25,7 @@ export const registerGetRcsNumberCapabilities = (server: McpServer, tags: Tags[]
     TOOL_NAME,
     {
       description:
-        'Returns the RCS features supported by a test number device (supported actions, rich card layouts, and ' +
-        'revocation).',
+        'Return RCS features supported by a specific RCS *test number* device for a given RCS sender (supported actions, rich card layouts, revocation). Requires senderId and the test phone number. Use when the user asks whether a tester can receive RCS / which RCS features their device supports. Do NOT use number-lookup for this — that checks carrier/line type, not RCS client capabilities.',
       inputSchema: GetRcsNumberCapabilitiesSchema,
     },
     getRcsNumberCapabilitiesHandler,

--- a/src/tools/verification/number-lookup.ts
+++ b/src/tools/verification/number-lookup.ts
@@ -24,7 +24,8 @@ export const registerNumberLookup = (server: McpServer, tags: Tags[]) => {
     server,
     TOOL_NAME,
     {
-      description: 'Look up a phone number for its status and capabilities.',
+      description:
+        'Look up line/carrier information for a phone number (E.164) via Number Lookup — validity, type, and related metadata. Use when the user asks whether a number is valid or what carrier/type it is. Do NOT use this for RCS device feature support (use get-rcs-number-capabilities), SMS verification codes (use start-sms-verification), or searching Sinch virtual numbers to rent (use search-for-available-numbers).',
       inputSchema: NumberLookupSchema,
     },
     numberLookupHandler,

--- a/src/tools/verification/start-sms-verification.ts
+++ b/src/tools/verification/start-sms-verification.ts
@@ -25,7 +25,7 @@ export const registerStartVerificationWithSms = (server: McpServer, tags: Tags[]
     TOOL_NAME,
     {
       description:
-        'Start new phone number verification requests. If the request is successful, you should ask the user to enter the OTP they received on the phone number we are verifying.',
+        'Start an SMS OTP verification for a phone number (E.164). Use when the user wants to *verify* ownership of a number via a one-time code. After success, ask them for the OTP and call report-sms-verification. Do NOT use number-lookup (carrier/line info) or send-text-message (arbitrary SMS content) for verification flows.',
       inputSchema: StartSmsVerificationSchema,
     },
     startSmsVerificationHandler,

--- a/src/tools/verification/start-sms-verification.ts
+++ b/src/tools/verification/start-sms-verification.ts
@@ -25,7 +25,7 @@ export const registerStartVerificationWithSms = (server: McpServer, tags: Tags[]
     TOOL_NAME,
     {
       description:
-        'Start an SMS OTP verification for a phone number (E.164). Use when the user wants to *verify* ownership of a number via a one-time code. After success, ask them for the OTP and call report-sms-verification. Do NOT use number-lookup (carrier/line info) or send-text-message (arbitrary SMS content) for verification flows.',
+        'Start an SMS OTP verification for a phone number (E.164). Use when the user wants to *verify* ownership of a number via a one-time code. After success, ask them for the OTP and call report-sms-verification. Do NOT use number-lookup (carrier/line info) or send-text-message (arbitrary SMS content) for phone number ownership verification flows.',
       inputSchema: StartSmsVerificationSchema,
     },
     startSmsVerificationHandler,

--- a/src/tools/voice/get-call-information.ts
+++ b/src/tools/voice/get-call-information.ts
@@ -24,7 +24,8 @@ export const registerGetCallInformation = (server: McpServer, tags: Tags[]) => {
     server,
     TOOL_NAME,
     {
-      description: 'Get information about a call using its ID',
+      description:
+        'Get status and details for an existing voice call by call ID. Use when the user asks about a specific call. Do not use this to place a new call (use tts-callout or conference-callout) or to send an SMS.',
       inputSchema: GetCallInformationSchema,
     },
     getCallInformationHandler,

--- a/src/tools/voice/tts-callout.ts
+++ b/src/tools/voice/tts-callout.ts
@@ -27,7 +27,8 @@ export const registerTtsCallout = (server: McpServer, tags: Tags[]) => {
     server,
     TOOL_NAME,
     {
-      description: 'Make a callout with a Text-To-Speech prompt',
+      description:
+        'Place an outbound voice call that speaks a text-to-speech message when answered. Use when the user wants to *call* a phone number and say something aloud. Do NOT use send-text-message for this. Requires phoneNumber and message — ask if either is missing.',
       inputSchema: TtsCalloutSchema,
     },
     ttsCalloutHandler,

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,10 +6,11 @@ Three layers:
   tool handlers and helpers in isolation. Run with `npm test`.
 - **LLM integration tests** ([`integration/llms`](integration/llms/README.md)) —
   drive the real MCP server with a real LLM to check tool routing (single pass,
-  CI gate). Run with `npm run test:integration`.
+  CI gate). Includes a **coverage gate** against live `tools/list` (not
+  `all.json`). Run with `npm run test:integration`.
 - **LLM evals** ([`eval/llms`](eval/llms/README.md)) — the same, but run many
   iterations and gate on a pass-rate, for probabilistic behaviour like
-  error-recovery. Run with `npm run test:eval`.
+  ambiguity / clarification and error-recovery. Run with `npm run test:eval`.
 
 ## Unit tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,8 +6,8 @@ Three layers:
   tool handlers and helpers in isolation. Run with `npm test`.
 - **LLM integration tests** ([`integration/llms`](integration/llms/README.md)) —
   drive the real MCP server with a real LLM to check tool routing (single pass,
-  CI gate). Includes a **coverage gate** against live `tools/list` (not
-  `all.json`). Run with `npm run test:integration`.
+  CI gate). Includes a **coverage gate** against live `tools/list`. Run with
+  `npm run test:integration`.
 - **LLM evals** ([`eval/llms`](eval/llms/README.md)) — the same, but run many
   iterations and gate on a pass-rate, for probabilistic behaviour like
   ambiguity / clarification and error-recovery. Run with `npm run test:eval`.

--- a/tests/eval/llms/README.md
+++ b/tests/eval/llms/README.md
@@ -53,9 +53,32 @@ Step assertions (all optional, combine as needed):
 
 - `accept` — passes if one of these tools was called.
 - `expectNoTool` — passes if **no** tool was called (the model just replies).
+- `allowNoTool` — with `accept`, a turn with no tool call also passes (clarify
+  **or** call one of `accept`).
+- `reject` — fails if any of these tools was called (ban a sibling, e.g. rent
+  when search/clarify is expected).
 - `responseIncludes` — the final assistant message contains each substring
-  (case-insensitive). Use this to check the model _surfaced_ something (e.g. an
-  unmet requirement) rather than claiming success.
+  (case-insensitive). Use this for tool-aware clarification (the model asks for
+  schema fields like phone/channel) or to check it _surfaced_ an unmet
+  requirement rather than claiming success.
+
+### Tool-aware clarification
+
+Users will not know every required parameter. `expectNoTool` alone cannot tell
+MCP-aware clarification from a generic chat reply. Pair it with
+`responseIncludes` for missing required fields (e.g. `phone`, `number`,
+`sms`/`whatsapp`), then a follow-up turn that supplies them and asserts
+`accept`.
+
+### Adding regression vs ambiguity cases
+
+- Clear happy-paths and trickier single-turn paraphrases →
+  [`fixtures/tool-cases.ts`](../../integration/llms/fixtures/tool-cases.ts)
+  (integration).
+- Under-specified / probabilistic clarify flows → an `*.eval.test.ts` here.
+- **TDD:** fix tool `description`s when cases fail — do not rewrite prompts.
+- Multi-step RCS launch/update uses **stateful** mocks (`enforceLaunch`), not
+  prompt-only checks — see `rcs-launch-recovery.eval.test.ts`.
 
 ## Config
 

--- a/tests/eval/llms/README.md
+++ b/tests/eval/llms/README.md
@@ -62,21 +62,17 @@ Step assertions (all optional, combine as needed):
   schema fields like phone/channel) or to check it _surfaced_ an unmet
   requirement rather than claiming success.
 
-### Tool-aware clarification
+### Where to add new cases (maintenance)
 
-Users will not know every required parameter. `expectNoTool` alone cannot tell
-MCP-aware clarification from a generic chat reply. Pair it with
-`responseIncludes` for missing required fields (e.g. `phone`, `number`,
-`sms`/`whatsapp`), then a follow-up turn that supplies them and asserts
-`accept`.
-
-### Adding regression vs ambiguity cases
+Use this as the authoring checklist when extending coverage:
 
 - Clear happy-paths and trickier single-turn paraphrases →
   [`fixtures/tool-cases.ts`](../../integration/llms/fixtures/tool-cases.ts)
   (integration).
 - Under-specified / probabilistic clarify flows → an `*.eval.test.ts` here.
-- **TDD:** fix tool `description`s when cases fail — do not rewrite prompts.
+  Pair `expectNoTool` with `responseIncludes` for missing required fields
+  (e.g. `phone`, `region`) so the reply is tool-aware, then assert `accept` on
+  the follow-up turn.
 - Multi-step RCS launch/update uses **stateful** mocks (`enforceLaunch`), not
   prompt-only checks — see `rcs-launch-recovery.eval.test.ts`.
 

--- a/tests/eval/llms/numbers-support-line-clarification.eval.test.ts
+++ b/tests/eval/llms/numbers-support-line-clarification.eval.test.ts
@@ -1,0 +1,24 @@
+import { defineWorkflowEval } from './utils/workflow-eval-harness';
+
+// Under-specified Numbers request: "support line" has no E.164 number — not
+// enough to rent. Clarify OR search is fine; rent with invented digits is not.
+defineWorkflowEval({
+  name: 'Virtual number support-line clarification',
+  debugFirstIteration: true,
+  passRate: 0.8,
+  steps: [
+    {
+      id: 'vague-support-line',
+      prompt: `Set up a virtual number for our support line.`,
+      accept: ['search-for-available-numbers'],
+      allowNoTool: true,
+      reject: ['rent-sinch-virtual-numbers'],
+    },
+    {
+      id: 'provide-search',
+      prompt: `Search for available US local numbers that support SMS in area code 415.`,
+      accept: ['search-for-available-numbers'],
+      reject: ['rent-sinch-virtual-numbers'],
+    },
+  ],
+});

--- a/tests/eval/llms/numbers-support-line-clarification.eval.test.ts
+++ b/tests/eval/llms/numbers-support-line-clarification.eval.test.ts
@@ -1,7 +1,8 @@
 import { defineWorkflowEval } from './utils/workflow-eval-harness';
 
-// Under-specified Numbers request: "support line" has no E.164 number — not
-// enough to rent. Clarify OR search is fine; rent with invented digits is not.
+// Ambiguity + multi-turn: "set up a virtual number" is under-specified and
+// search alone does not activate a number. The model must clarify first, then
+// search, then rent a concrete E.164 — never invent digits for rent.
 defineWorkflowEval({
   name: 'Virtual number support-line clarification',
   debugFirstIteration: true,
@@ -10,8 +11,8 @@ defineWorkflowEval({
     {
       id: 'vague-support-line',
       prompt: `Set up a virtual number for our support line.`,
-      accept: ['search-for-available-numbers'],
-      allowNoTool: true,
+      expectNoTool: true,
+      responseIncludes: ['region'],
       reject: ['rent-sinch-virtual-numbers'],
     },
     {
@@ -19,6 +20,11 @@ defineWorkflowEval({
       prompt: `Search for available US local numbers that support SMS in area code 415.`,
       accept: ['search-for-available-numbers'],
       reject: ['rent-sinch-virtual-numbers'],
+    },
+    {
+      id: 'rent-chosen-number',
+      prompt: `Rent / activate +14155550123 for the project.`,
+      accept: ['rent-sinch-virtual-numbers'],
     },
   ],
 });

--- a/tests/eval/llms/send-message-clarification.eval.test.ts
+++ b/tests/eval/llms/send-message-clarification.eval.test.ts
@@ -4,6 +4,8 @@ import { defineWorkflowEval } from './utils/workflow-eval-harness';
 // no phone number available anywhere in context. It must ask a clarifying
 // question (no tool call) instead of guessing a number, then call the tool
 // once the user supplies it in E.164 format.
+// responseIncludes proves the ask is tool-aware (required schema fields), not
+// a generic reply as if no MCP server were plugged in.
 defineWorkflowEval({
   name: 'Send message clarification',
   debugFirstIteration: true,
@@ -13,6 +15,7 @@ defineWorkflowEval({
       id: 'ambiguous-send',
       prompt: `Send a message to Antoine to say Hi`,
       expectNoTool: true,
+      responseIncludes: ['phone', 'number'],
     },
     {
       id: 'provide-number',

--- a/tests/eval/llms/utils/workflow-eval-harness.ts
+++ b/tests/eval/llms/utils/workflow-eval-harness.ts
@@ -17,6 +17,13 @@ export interface EvalStep {
   accept?: string[];
   /** If true, passes only if NO tool is called (the model just responds). */
   expectNoTool?: boolean;
+  /**
+   * With `accept`: a turn with no tool call also passes (clarify OR call one of
+   * accept). Use for under-specified intents where either behaviour is correct.
+   */
+  allowNoTool?: boolean;
+  /** Fails if ANY of these tools is called (e.g. ban rent when search/clarify is expected). */
+  reject?: string[];
   /** Also require the final assistant message to contain each of these (case-insensitive). */
   responseIncludes?: string[];
 }
@@ -71,11 +78,18 @@ const stepPasses = (step: EvalStep, result: PromptResult): boolean => {
     return false;
   }
   const called = result.toolsCalled();
+  if (step.reject?.some((tool) => called.includes(tool))) {
+    return false;
+  }
   if (step.expectNoTool && called.length > 0) {
     return false;
   }
-  if (step.accept && !step.accept.some((tool) => called.includes(tool))) {
-    return false;
+  if (step.accept) {
+    const matched = step.accept.some((tool) => called.includes(tool));
+    const noToolOk = Boolean(step.allowNoTool) && called.length === 0;
+    if (!matched && !noToolOk) {
+      return false;
+    }
   }
   if (step.responseIncludes) {
     const text = finalAssistantText(result).toLowerCase();

--- a/tests/eval/llms/vague-channel-clarification.eval.test.ts
+++ b/tests/eval/llms/vague-channel-clarification.eval.test.ts
@@ -1,0 +1,24 @@
+import { defineWorkflowEval } from './utils/workflow-eval-harness';
+
+// Under-specified channel setup: the model must ask which channel (SMS / RCS /
+// WhatsApp) and collect credentials — not invent them or call a set-*-channel
+// tool. responseIncludes proves the clarification is tool-aware (schema fields),
+// not a generic chat reply as if no MCP server were connected.
+defineWorkflowEval({
+  name: 'Vague channel setup clarification',
+  debugFirstIteration: true,
+  passRate: 0.8,
+  steps: [
+    {
+      id: 'vague-add-messaging',
+      prompt: `Add messaging to Conversation app app-abc123`,
+      expectNoTool: true,
+      responseIncludes: ['sms'],
+    },
+    {
+      id: 'provide-whatsapp',
+      prompt: `WhatsApp — sender id wa-sender-1 and bearer token wa-token-1`,
+      accept: ['set-whatsapp-channel-on-app'],
+    },
+  ],
+});

--- a/tests/integration/llms/README.md
+++ b/tests/integration/llms/README.md
@@ -59,11 +59,7 @@ Folder = role: **tests** at the top level, **utils/** reusable machinery,
 [`tool-coverage.int.test.ts`](tool-coverage.int.test.ts) starts the in-process
 server, reads the live tool names from `client.listTools()`, and asserts each
 name appears in LLM fixtures (`expectedToolName` / `accept` in
-[`fixtures/tool-cases.ts`](fixtures/tool-cases.ts), plus
-`MULTI_TURN_ACCEPT_TOOLS` for workflow/eval-only tools).
-
-**Do not** use `tests/fixtures/server/tag-filtering/all.json` for this — that
-file is hand-maintained for tag-filtering unit tests only.
+[`fixtures/tool-cases.ts`](fixtures/tool-cases.ts)).
 
 No provider API key is required for the coverage gate.
 
@@ -77,9 +73,6 @@ Both live primarily in [`fixtures/tool-cases.ts`](fixtures/tool-cases.ts):
   number for SMS”) that must still route to the correct sibling tool. Prefer
   adding these next to the happy-path case. Promote flaky cases to
   [`tests/eval/llms`](../../eval/llms/README.md).
-
-**TDD rule:** if routing fails, rewrite the tool `description` (and schema
-`.describe()` text) — do **not** soften the prompt.
 
 ## Two kinds of test
 

--- a/tests/integration/llms/README.md
+++ b/tests/integration/llms/README.md
@@ -36,6 +36,7 @@ is no next turn), needing no service mocks at all.
 
 ```
 tests/integration/llms/
+├── tool-coverage.int.test.ts             every tools/list name appears in LLM fixtures
 ├── tool-invocation.int.test.ts          single-turn tool-selection matrix (all providers)
 ├── rcs-onboarding-workflow.int.test.ts   multi-turn workflow (just declares its steps)
 ├── utils/
@@ -46,11 +47,39 @@ tests/integration/llms/
 │   └── sinch-fakes.ts                    registerSinchMocks — jest-mocked service clients
 └── fixtures/
     ├── tool-cases.ts                     single-turn prompt → expected tool/args data
+    ├── llm-tool-coverage.ts              collect covered tool names for the gate
     └── config.ts                         TEMPERATURE / TIMEOUT
 ```
 
 Folder = role: **tests** at the top level, **utils/** reusable machinery,
 **mocks/** the fake service clients, **fixtures/** static data.
+
+## Coverage gate (`tools/list`)
+
+[`tool-coverage.int.test.ts`](tool-coverage.int.test.ts) starts the in-process
+server, reads the live tool names from `client.listTools()`, and asserts each
+name appears in LLM fixtures (`expectedToolName` / `accept` in
+[`fixtures/tool-cases.ts`](fixtures/tool-cases.ts), plus
+`MULTI_TURN_ACCEPT_TOOLS` for workflow/eval-only tools).
+
+**Do not** use `tests/fixtures/server/tag-filtering/all.json` for this — that
+file is hand-maintained for tag-filtering unit tests only.
+
+No provider API key is required for the coverage gate.
+
+## Regression vs ambiguity (single-turn)
+
+Both live primarily in [`fixtures/tool-cases.ts`](fixtures/tool-cases.ts):
+
+- **Regression** — clear happy-path prompts that already include required args;
+  assert tool name (+ partial args).
+- **Ambiguity** — trickier paraphrases (e.g. “area code 415”, “San Francisco
+  number for SMS”) that must still route to the correct sibling tool. Prefer
+  adding these next to the happy-path case. Promote flaky cases to
+  [`tests/eval/llms`](../../eval/llms/README.md).
+
+**TDD rule:** if routing fails, rewrite the tool `description` (and schema
+`.describe()` text) — do **not** soften the prompt.
 
 ## Two kinds of test
 

--- a/tests/integration/llms/fixtures/llm-tool-coverage.ts
+++ b/tests/integration/llms/fixtures/llm-tool-coverage.ts
@@ -1,40 +1,13 @@
 import { toolTestCases, ToolTestCase } from './tool-cases';
 
-/**
- * Tools covered by multi-turn workflow / eval `accept` lists.
- * Keep in sync when adding `accept: [...]` in workflow or eval suites —
- * the coverage gate asserts every live `tools/list` name appears here or in
- * tool-cases (not in hand-maintained all.json).
- */
-export const MULTI_TURN_ACCEPT_TOOLS: readonly string[] = [
-  'create-rcs-sender',
-  'get-rcs-sender',
-  'list-rcs-senders',
-  'update-rcs-sender',
-  'add-rcs-test-number',
-  'launch-rcs-sender',
-  'set-sms-channel-on-app',
-  'send-text-message',
-];
+/** Collect tool names covered by single-turn LLM fixtures (`expectedToolName` / `accept`). */
+export const collectCoveredToolsFromCases = (cases: ToolTestCase[]): Set<string> =>
+  new Set(
+    cases.flatMap((testCase) => [
+      ...(testCase.expectedToolName ? [testCase.expectedToolName] : []),
+      ...(testCase.accept ?? []),
+    ]),
+  );
 
-export const collectCoveredToolsFromCases = (cases: ToolTestCase[]): Set<string> => {
-  const covered = new Set<string>();
-  for (const testCase of cases) {
-    if (testCase.expectedToolName) {
-      covered.add(testCase.expectedToolName);
-    }
-    for (const name of testCase.accept ?? []) {
-      covered.add(name);
-    }
-  }
-  return covered;
-};
-
-/** All tool names exercised by LLM fixtures (single-turn + multi-turn accept lists). */
-export const collectFixtureCoveredTools = (): Set<string> => {
-  const covered = collectCoveredToolsFromCases(toolTestCases);
-  for (const name of MULTI_TURN_ACCEPT_TOOLS) {
-    covered.add(name);
-  }
-  return covered;
-};
+/** Tool names exercised by LLM fixtures (derived from tool-cases only — no hand-maintained list). */
+export const collectFixtureCoveredTools = (): Set<string> => collectCoveredToolsFromCases(toolTestCases);

--- a/tests/integration/llms/fixtures/llm-tool-coverage.ts
+++ b/tests/integration/llms/fixtures/llm-tool-coverage.ts
@@ -1,0 +1,40 @@
+import { toolTestCases, ToolTestCase } from './tool-cases';
+
+/**
+ * Tools covered by multi-turn workflow / eval `accept` lists.
+ * Keep in sync when adding `accept: [...]` in workflow or eval suites —
+ * the coverage gate asserts every live `tools/list` name appears here or in
+ * tool-cases (not in hand-maintained all.json).
+ */
+export const MULTI_TURN_ACCEPT_TOOLS: readonly string[] = [
+  'create-rcs-sender',
+  'get-rcs-sender',
+  'list-rcs-senders',
+  'update-rcs-sender',
+  'add-rcs-test-number',
+  'launch-rcs-sender',
+  'set-sms-channel-on-app',
+  'send-text-message',
+];
+
+export const collectCoveredToolsFromCases = (cases: ToolTestCase[]): Set<string> => {
+  const covered = new Set<string>();
+  for (const testCase of cases) {
+    if (testCase.expectedToolName) {
+      covered.add(testCase.expectedToolName);
+    }
+    for (const name of testCase.accept ?? []) {
+      covered.add(name);
+    }
+  }
+  return covered;
+};
+
+/** All tool names exercised by LLM fixtures (single-turn + multi-turn accept lists). */
+export const collectFixtureCoveredTools = (): Set<string> => {
+  const covered = collectCoveredToolsFromCases(toolTestCases);
+  for (const name of MULTI_TURN_ACCEPT_TOOLS) {
+    covered.add(name);
+  }
+  return covered;
+};

--- a/tests/integration/llms/fixtures/tool-cases.ts
+++ b/tests/integration/llms/fixtures/tool-cases.ts
@@ -116,6 +116,26 @@ const messagingCases: ToolTestCase[] = [
     },
   },
   {
+    prompt:
+      'Set the RCS channel on Conversation app app-abc123 using RCS auth name my-rcs-auth and bearer token my-rcs-token.',
+    expectedToolName: 'set-rcs-channel-on-app',
+    expectedArguments: {
+      appId: 'app-abc123',
+      senderId: 'my-rcs-auth',
+      bearerToken: 'my-rcs-token',
+    },
+  },
+  {
+    prompt:
+      'Set the WhatsApp channel on Conversation app app-abc123 with WhatsApp sender id wa-sender-1 and bearer token wa-token-1.',
+    expectedToolName: 'set-whatsapp-channel-on-app',
+    expectedArguments: {
+      appId: 'app-abc123',
+      senderId: 'wa-sender-1',
+      bearerToken: 'wa-token-1',
+    },
+  },
+  {
     prompt: 'Rename Conversation app app-abc123 to My Support Bot.',
     expectedToolName: 'update-conversation-app',
     expectedArguments: {
@@ -141,6 +161,13 @@ const messagingCases: ToolTestCase[] = [
     expectedArguments: undefined,
   },
   {
+    prompt: 'Show me the details of webhook wh-abc123.',
+    expectedToolName: 'get-webhook',
+    expectedArguments: {
+      webhookId: 'wh-abc123',
+    },
+  },
+  {
     prompt: 'Create a webhook for inbound messages at https://example.com/callback with triggers MESSAGE_INBOUND.',
     expectedToolName: 'create-webhook',
     expectedArguments: {
@@ -154,6 +181,133 @@ const messagingCases: ToolTestCase[] = [
     expectedArguments: {
       webhookId: 'wh-abc123',
       triggers: [],
+    },
+  },
+  {
+    prompt: 'Delete webhook wh-abc123.',
+    expectedToolName: 'delete-webhook',
+    expectedArguments: {
+      webhookId: 'wh-abc123',
+    },
+  },
+];
+
+// Numbers API: search, rent, list, release, regions.
+const numbersCases: ToolTestCase[] = [
+  {
+    prompt: 'Search for available US local numbers that can do SMS.',
+    expectedToolName: 'search-for-available-numbers',
+    expectedArguments: {
+      regionCode: 'US',
+      type: 'LOCAL',
+      capabilities: ['SMS'],
+    },
+  },
+  // Trickier wording — still search, not rent.
+  {
+    prompt: 'I need a US local number in area code 415',
+    expectedToolName: 'search-for-available-numbers',
+    expectedArguments: {
+      regionCode: 'US',
+      type: 'LOCAL',
+    },
+    pathMatchers: {
+      searchPattern: /415/,
+    },
+  },
+  {
+    prompt: 'Can you get me a San Francisco number for SMS?',
+    expectedToolName: 'search-for-available-numbers',
+    expectedArguments: {
+      regionCode: 'US',
+      capabilities: ['SMS'],
+    },
+  },
+  {
+    prompt: 'Activate / rent this number +14155550123 for my project.',
+    expectedToolName: 'rent-sinch-virtual-numbers',
+    expectedArguments: {
+      numbers: ['+14155550123'],
+    },
+  },
+  {
+    prompt: 'List all active rented phone numbers on my account.',
+    expectedToolName: 'list-rented-numbers',
+    expectedArguments: undefined,
+  },
+  {
+    prompt: 'Release the rented phone number +14155550123 from my project.',
+    expectedToolName: 'release-rented-number',
+    expectedArguments: {
+      phoneNumber: '+14155550123',
+    },
+  },
+  {
+    prompt: 'Which regions can I buy virtual numbers in?',
+    expectedToolName: 'list-available-regions',
+    expectedArguments: undefined,
+  },
+];
+
+// RCS helpers (create/get/update/launch covered in multi-turn; these fill single-turn gaps).
+const rcsCases: ToolTestCase[] = [
+  {
+    prompt: 'Delete test number +3412345678900 from RCS sender snd_abc123.',
+    expectedToolName: 'delete-rcs-test-number',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+      testNumber: '+3412345678900',
+    },
+  },
+  {
+    prompt: 'Resend the RCS test invite for +3412345678900 on sender snd_abc123.',
+    expectedToolName: 'resend-rcs-test-number-invite',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+      testNumber: '+3412345678900',
+    },
+  },
+  {
+    prompt: 'What is the verification state of RCS test number +3412345678900 on sender snd_abc123?',
+    expectedToolName: 'get-rcs-test-number-state',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+      testNumber: '+3412345678900',
+    },
+  },
+  {
+    prompt: 'Which RCS features does test number +3412345678900 support on sender snd_abc123?',
+    expectedToolName: 'get-rcs-number-capabilities',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+      testNumber: '+3412345678900',
+    },
+  },
+];
+
+// Ambiguity / sibling-tool routing — trickier wording, still a deterministic expected tool.
+const ambiguityCases: ToolTestCase[] = [
+  {
+    prompt: 'Can +33612345678 receive RCS? Check capabilities for sender snd_abc123 and test number +33612345678.',
+    expectedToolName: 'get-rcs-number-capabilities',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+      testNumber: '+33612345678',
+    },
+  },
+  {
+    prompt: 'Verify +33612345678',
+    expectedToolName: 'start-sms-verification',
+    expectedArguments: { phoneNumber: '+33612345678' },
+  },
+  {
+    prompt:
+      "Send Antoine a WhatsApp template message using template 'appt_reminder' in Spanish with parameter name set to Mr. Smith. His number is +33612345678.",
+    expectedToolName: 'send-whatsapp-template-message',
+    expectedArguments: {
+      recipient: '+33612345678',
+      templateName: 'appt_reminder',
+      templateLanguage: 'es',
     },
   },
 ];
@@ -294,13 +448,23 @@ const voiceCases: ToolTestCase[] = [
       conferenceId: 'abc123',
     },
   },
+  {
+    prompt: 'Get information about call call-xyz-789.',
+    expectedToolName: 'get-call-information',
+    expectedArguments: {
+      callId: 'call-xyz-789',
+    },
+  },
 ];
 
 export const toolTestCases: ToolTestCase[] = [
   ...generalCases,
   ...messagingCases,
+  ...numbersCases,
+  ...rcsCases,
   ...whatsappTemplateCases,
   ...verificationCases,
   ...emailCases,
   ...voiceCases,
+  ...ambiguityCases,
 ];

--- a/tests/integration/llms/fixtures/tool-cases.ts
+++ b/tests/integration/llms/fixtures/tool-cases.ts
@@ -210,9 +210,8 @@ const numbersCases: ToolTestCase[] = [
     expectedArguments: {
       regionCode: 'US',
       type: 'LOCAL',
-    },
-    pathMatchers: {
-      searchPattern: /415/,
+      searchPattern: '415',
+      patternPosition: 'START',
     },
   },
   {
@@ -249,10 +248,55 @@ const numbersCases: ToolTestCase[] = [
   },
 ];
 
-// RCS helpers (create/get/update/launch covered in multi-turn; these fill single-turn gaps).
+// RCS agent tools (single-turn coverage; multi-turn onboarding/evals exercise flows).
 const rcsCases: ToolTestCase[] = [
   {
-    prompt: 'Delete test number +3412345678900 from RCS sender snd_abc123.',
+    prompt:
+      "Create a new RCS agent named 'AcmeCorp' in the US region, with a TRANSACTIONAL use case and a conversational billing category.",
+    expectedToolName: 'create-rcs-sender',
+    expectedArguments: {
+      region: 'US',
+      useCase: 'TRANSACTIONAL',
+      billingCategory: 'CONVERSATIONAL',
+    },
+  },
+  {
+    prompt: 'Get the details of RCS agent snd_abc123.',
+    expectedToolName: 'get-rcs-sender',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+    },
+  },
+  {
+    prompt: 'List all RCS agents in my project.',
+    expectedToolName: 'list-rcs-senders',
+    expectedArguments: undefined,
+  },
+  {
+    prompt:
+      'Update RCS agent snd_abc123 with privacy policy URL https://example.com/privacy and terms of service URL https://example.com/terms.',
+    expectedToolName: 'update-rcs-sender',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+    },
+  },
+  {
+    prompt: 'Add +3412345678900 as a test number on RCS agent snd_abc123.',
+    expectedToolName: 'add-rcs-test-number',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+      testNumbers: ['+3412345678900'],
+    },
+  },
+  {
+    prompt: 'Launch RCS agent snd_abc123 now.',
+    expectedToolName: 'launch-rcs-sender',
+    expectedArguments: {
+      senderId: 'snd_abc123',
+    },
+  },
+  {
+    prompt: 'Delete test number +3412345678900 from RCS agent snd_abc123.',
     expectedToolName: 'delete-rcs-test-number',
     expectedArguments: {
       senderId: 'snd_abc123',
@@ -260,7 +304,7 @@ const rcsCases: ToolTestCase[] = [
     },
   },
   {
-    prompt: 'Resend the RCS test invite for +3412345678900 on sender snd_abc123.',
+    prompt: 'Resend the RCS test invite for +3412345678900 on agent snd_abc123.',
     expectedToolName: 'resend-rcs-test-number-invite',
     expectedArguments: {
       senderId: 'snd_abc123',
@@ -268,7 +312,7 @@ const rcsCases: ToolTestCase[] = [
     },
   },
   {
-    prompt: 'What is the verification state of RCS test number +3412345678900 on sender snd_abc123?',
+    prompt: 'What is the verification state of RCS test number +3412345678900 on agent snd_abc123?',
     expectedToolName: 'get-rcs-test-number-state',
     expectedArguments: {
       senderId: 'snd_abc123',
@@ -276,7 +320,7 @@ const rcsCases: ToolTestCase[] = [
     },
   },
   {
-    prompt: 'Which RCS features does test number +3412345678900 support on sender snd_abc123?',
+    prompt: 'Which RCS features does test number +3412345678900 support on agent snd_abc123?',
     expectedToolName: 'get-rcs-number-capabilities',
     expectedArguments: {
       senderId: 'snd_abc123',
@@ -288,7 +332,7 @@ const rcsCases: ToolTestCase[] = [
 // Ambiguity / sibling-tool routing — trickier wording, still a deterministic expected tool.
 const ambiguityCases: ToolTestCase[] = [
   {
-    prompt: 'Can +33612345678 receive RCS? Check capabilities for sender snd_abc123 and test number +33612345678.',
+    prompt: 'Can +33612345678 receive RCS? Check capabilities for RCS agent snd_abc123 and test number +33612345678.',
     expectedToolName: 'get-rcs-number-capabilities',
     expectedArguments: {
       senderId: 'snd_abc123',

--- a/tests/integration/llms/tool-coverage.int.test.ts
+++ b/tests/integration/llms/tool-coverage.int.test.ts
@@ -1,0 +1,33 @@
+import { startInProcessServer } from './utils/in-process-server';
+import { collectFixtureCoveredTools } from './fixtures/llm-tool-coverage';
+
+/**
+ * Coverage gate: every tool advertised by the live MCP server (`tools/list`
+ * via the in-process client) must appear in LLM fixtures.
+ *
+ * Source of truth is listTools() — not hand-maintained all.json (that fixture
+ * is only for tag-filtering unit tests).
+ *
+ * Does not need a provider API key.
+ */
+describe('LLM tool coverage vs tools/list', () => {
+  it('covers every registered tool name in fixtures', async () => {
+    const server = await startInProcessServer();
+    try {
+      const registered = server.tools.map((tool) => tool.name).sort();
+      const covered = collectFixtureCoveredTools();
+      const missing = registered.filter((name) => !covered.has(name));
+
+      if (missing.length > 0) {
+        console.log(
+          `[LLM coverage] missing fixtures for:\n${missing.map((name) => `  - ${name}`).join('\n')}\n` +
+            `Add a case in fixtures/tool-cases.ts (expectedToolName) or MULTI_TURN_ACCEPT_TOOLS.`,
+        );
+      }
+
+      expect(missing).toEqual([]);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/tests/integration/llms/tool-invocation.int.test.ts
+++ b/tests/integration/llms/tool-invocation.int.test.ts
@@ -43,74 +43,74 @@ const PROVIDERS: Provider[] = [
   .map((p) => ({ ...p, apiKey: apiKeyFor(p.model) }))
   .filter((p): p is Provider => Boolean(p.apiKey));
 
-// An empty matrix is a Jest error, so register a placeholder when no key is set.
+// An empty matrix is a Jest error — skip describe.each when no key is set.
 if (PROVIDERS.length === 0) {
   it('skips — no provider API key (ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY)', () => {
     expect(PROVIDERS).toHaveLength(0);
   });
-}
+} else {
+  describe.each(PROVIDERS)('Tool invocation — $name ($model)', ({ model, apiKey }: Provider) => {
+    let server: InProcessServer;
+    let agent: HostRunner;
 
-describe.each(PROVIDERS)('Tool invocation — $name ($model)', ({ model, apiKey }: Provider) => {
-  let server: InProcessServer;
-  let agent: HostRunner;
+    beforeAll(async () => {
+      server = await startInProcessServer();
+      const tools = server.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        execute: async () => STUB_TOOL_RESULT,
+      }));
+      agent = new HostRunner({ tools: tools as never, model, apiKey, temperature: TEMPERATURE, maxSteps: 1 });
+      await preflight(agent, model);
+    }, 60_000);
 
-  beforeAll(async () => {
-    server = await startInProcessServer();
-    const tools = server.tools.map((tool) => ({
-      name: tool.name,
-      description: tool.description,
-      inputSchema: tool.inputSchema,
-      execute: async () => STUB_TOOL_RESULT,
-    }));
-    agent = new HostRunner({ tools: tools as never, model, apiKey, temperature: TEMPERATURE, maxSteps: 1 });
-    await preflight(agent, model);
-  }, 60_000);
+    afterAll(async () => {
+      await server?.close();
+    });
 
-  afterAll(async () => {
-    await server?.close();
-  });
-
-  it.each(toolTestCases)(
-    'handles "$prompt"',
-    async ({ prompt, expectedToolName, expectedArguments, pathMatchers, accept }) => {
-      const result = await agent.run(prompt);
-      if (result.hasError()) {
-        throw new Error(`${model} run failed: ${result.getError()}`);
-      }
-
-      const acceptedTools = accept ?? (expectedToolName ? [expectedToolName] : []);
-      if (acceptedTools.length === 0) {
-        expect(result.toolsCalled()).toHaveLength(0);
-        return;
-      }
-      expect(acceptedTools.some((tool) => result.hasToolCall(tool))).toBeTrue();
-
-      if (expectedToolName && expectedArguments) {
-        const calls = result.getToolCalls();
-        const matched = matchToolCallWithPartialArgs(expectedToolName, expectedArguments, calls);
-        if (!matched) {
-          console.log(
-            `[DEBUG] "${prompt}"\n  expected: ${expectedToolName} ${JSON.stringify(expectedArguments)}\n  actual:   ${JSON.stringify(calls)}`,
-          );
+    it.each(toolTestCases)(
+      'handles "$prompt"',
+      async ({ prompt, expectedToolName, expectedArguments, pathMatchers, accept }) => {
+        const result = await agent.run(prompt);
+        if (result.hasError()) {
+          throw new Error(`${model} run failed: ${result.getError()}`);
         }
-        expect(matched).toBeTrue();
-      }
 
-      if (expectedToolName && pathMatchers && Object.keys(pathMatchers).length > 0) {
-        const call = result.getToolCalls().find((c) => c.toolName === expectedToolName);
-        expect(call).toBeDefined();
-        for (const path in pathMatchers) {
-          const expected = pathMatchers[path];
-          const actual = getPath(call!.arguments, path);
-          if (!pathMatches(expected, actual)) {
+        const acceptedTools = accept ?? (expectedToolName ? [expectedToolName] : []);
+        if (acceptedTools.length === 0) {
+          expect(result.toolsCalled()).toHaveLength(0);
+          return;
+        }
+        expect(acceptedTools.some((tool) => result.hasToolCall(tool))).toBeTrue();
+
+        if (expectedToolName && expectedArguments) {
+          const calls = result.getToolCalls();
+          const matched = matchToolCallWithPartialArgs(expectedToolName, expectedArguments, calls);
+          if (!matched) {
             console.log(
-              `[DEBUG] "${prompt}"\n  field: ${path}\n  expected: ${expected}\n  actual:   ${JSON.stringify(actual)}`,
+              `[DEBUG] "${prompt}"\n  expected: ${expectedToolName} ${JSON.stringify(expectedArguments)}\n  actual:   ${JSON.stringify(calls)}`,
             );
           }
-          expect(pathMatches(expected, actual)).toBeTrue();
+          expect(matched).toBeTrue();
         }
-      }
-    },
-    TIMEOUT,
-  );
-});
+
+        if (expectedToolName && pathMatchers && Object.keys(pathMatchers).length > 0) {
+          const call = result.getToolCalls().find((c) => c.toolName === expectedToolName);
+          expect(call).toBeDefined();
+          for (const path in pathMatchers) {
+            const expected = pathMatchers[path];
+            const actual = getPath(call!.arguments, path);
+            if (!pathMatches(expected, actual)) {
+              console.log(
+                `[DEBUG] "${prompt}"\n  field: ${path}\n  expected: ${expected}\n  actual:   ${JSON.stringify(actual)}`,
+              );
+            }
+            expect(pathMatches(expected, actual)).toBeTrue();
+          }
+        }
+      },
+      TIMEOUT,
+    );
+  });
+}


### PR DESCRIPTION
Gate fixture coverage against live tools/list, add regression and trickier prompts for previously uncovered tools, and clarify under-specified intents with tool-aware evals—fixing descriptions instead of prompts when routing fails.