### PR TITLE
Fix: DEVEXP-1517 fix sonar qube issues

### DIFF
--- a/src/auth/credential-context.ts
+++ b/src/auth/credential-context.ts
@@ -1,5 +1,5 @@
-import { AsyncLocalStorage } from 'async_hooks';
-import type { IncomingHttpHeaders } from 'http';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { IncomingHttpHeaders } from 'node:http';
 import {
   parseSinchCredentialsHeader,
   SINCH_CREDENTIALS_HEADER,

--- a/src/auth/mcp-api-key.ts
+++ b/src/auth/mcp-api-key.ts
@@ -1,4 +1,4 @@
-import { createHash, timingSafeEqual } from 'crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { NextFunction, Request, Response } from 'express';
 
 const BEARER_SCHEME = 'bearer';
@@ -65,12 +65,14 @@ export const loadMcpApiKeys = (): string[] => {
 };
 
 export const extractBearerToken = (authorizationHeader: string | string[] | undefined): string | undefined => {
-  const headers =
-    authorizationHeader === undefined
-      ? []
-      : Array.isArray(authorizationHeader)
-        ? authorizationHeader
-        : [authorizationHeader];
+  let headers: string[];
+  if (authorizationHeader === undefined) {
+    headers = [];
+  } else if (Array.isArray(authorizationHeader)) {
+    headers = authorizationHeader;
+  } else {
+    headers = [authorizationHeader];
+  }
 
   for (const header of headers) {
     if (!header) {

--- a/src/auth/sinch-oauth-credentials.ts
+++ b/src/auth/sinch-oauth-credentials.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { env } from '../env';
 
 export const SINCH_CREDENTIALS_HEADER = 'x-sinch-credentials';

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import express, { type Request, type Response } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';

--- a/src/tools/conversation/utils/app-tools-helper.ts
+++ b/src/tools/conversation/utils/app-tools-helper.ts
@@ -1,5 +1,4 @@
-import { Conversation } from '@sinch/conversation';
-import { ConversationService } from '@sinch/conversation';
+import { Conversation, ConversationService } from '@sinch/conversation';
 import { IPromptResponse, PromptResponse } from '../../../types';
 import { appendRegionHint } from './region-hint';
 import { formatAppResponse } from './format-app-response';

--- a/src/tools/conversation/utils/build-channel-credential.ts
+++ b/src/tools/conversation/utils/build-channel-credential.ts
@@ -54,96 +54,36 @@ const optionalRequestFields = (credential: Conversation.ConversationChannelCrede
   ...(credential.callback_secret !== undefined ? { callback_secret: credential.callback_secret } : {}),
 });
 
+// Every channel keeps its credential under exactly one of these keys, and the response
+// shape for each one is identical to the request shape (see StaticBearerCredential,
+// StaticTokenCredential, MMSCredentials, etc. in @sinch/conversation), so a passthrough
+// copy is all that's needed. Add new channels here as the SDK adds them.
+const CREDENTIAL_FIELDS = [
+  'static_bearer',
+  'static_token',
+  'mms_credentials',
+  'instagram_credentials',
+  'telegram_credentials',
+  'kakaotalk_credentials',
+  'kakaotalkchat_credentials',
+  'line_credentials',
+  'line_enterprise_credentials',
+  'wechat_credentials',
+  'applebc_credentials',
+] as const;
+
 export const toChannelCredentialRequest = (
   credential: Conversation.ConversationChannelCredentialResponse,
 ): Conversation.ConversationChannelCredentialRequest => {
-  const optional = optionalRequestFields(credential);
+  const base = { channel: credential.channel, ...optionalRequestFields(credential) };
+  const source = credential as unknown as Record<string, unknown>;
 
-  if ('static_bearer' in credential && credential.static_bearer) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      static_bearer: {
-        claimed_identity: credential.static_bearer.claimed_identity,
-        token: credential.static_bearer.token,
-      },
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('static_token' in credential && credential.static_token) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      static_token: {
-        token: credential.static_token.token,
-      },
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('mms_credentials' in credential && credential.mms_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      mms_credentials: credential.mms_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('instagram_credentials' in credential && credential.instagram_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      instagram_credentials: credential.instagram_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('telegram_credentials' in credential && credential.telegram_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      telegram_credentials: credential.telegram_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('kakaotalk_credentials' in credential && credential.kakaotalk_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      kakaotalk_credentials: credential.kakaotalk_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('kakaotalkchat_credentials' in credential && credential.kakaotalkchat_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      kakaotalkchat_credentials: credential.kakaotalkchat_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('line_credentials' in credential && credential.line_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      line_credentials: credential.line_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('line_enterprise_credentials' in credential && credential.line_enterprise_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      line_enterprise_credentials: credential.line_enterprise_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('wechat_credentials' in credential && credential.wechat_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      wechat_credentials: credential.wechat_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
-  }
-  if ('applebc_credentials' in credential && credential.applebc_credentials) {
-    return {
-      channel: credential.channel,
-      ...optional,
-      applebc_credentials: credential.applebc_credentials,
-    } as Conversation.ConversationChannelCredentialRequest;
+  for (const field of CREDENTIAL_FIELDS) {
+    const value = source[field];
+    if (value) {
+      return { ...base, [field]: value } as Conversation.ConversationChannelCredentialRequest;
+    }
   }
 
-  return {
-    channel: credential.channel,
-    ...optional,
-  } as Conversation.ConversationChannelCredentialRequest;
+  return base as Conversation.ConversationChannelCredentialRequest;
 };

--- a/src/tools/conversation/utils/format-list-all-apps-response.ts
+++ b/src/tools/conversation/utils/format-list-all-apps-response.ts
@@ -1,7 +1,7 @@
 import { Conversation } from '@sinch/conversation';
 
 export const formatListAllAppsResponse = (response: Conversation.ListAppsResponse | undefined) => {
-  if (!response || !response.apps) {
+  if (!response?.apps) {
     return { apps: [] };
   }
   return {

--- a/src/tools/email/list-email-events.ts
+++ b/src/tools/email/list-email-events.ts
@@ -19,6 +19,24 @@ const eventTypes = [
 ] as const;
 
 type EventType = (typeof eventTypes)[number];
+type MailgunEventFields = { recipient?: string; subject?: string; from?: string };
+type EmailEventGroup = MailgunEventFields & { events: { event: string; timestamp: string }[] };
+interface MailgunEventsResponse {
+  items: MailgunEvent[];
+}
+
+interface MailgunEvent {
+  timestamp?: number;
+  event?: EventType;
+  recipient?: string;
+  message?: {
+    headers: {
+      'message-id': string;
+      from?: string;
+      subject?: string;
+    };
+  };
+}
 
 const ListEmailEventsSchema = {
   domain: z.string().optional().describe('(Optional) The Mailgun domain to fetch events for.'),
@@ -71,23 +89,7 @@ export const listEmailEventsHandler = async ({
   }
   const credentials = maybeCredentials;
 
-  const params = new URLSearchParams();
-  if (event) {
-    params.append('event', event);
-  }
-  if (limit) {
-    params.append('limit', limit.toString());
-  }
-  if (beginSearchPeriod) {
-    params.append('begin', (new Date(beginSearchPeriod).getTime() / 1000).toString());
-  }
-  if (endSearchPeriod) {
-    params.append('end', (new Date(endSearchPeriod).getTime() / 1000).toString());
-  }
-  if (beginSearchPeriod && !endSearchPeriod) {
-    params.append('end', (new Date().getTime() / 1000).toString()); // Default to now if no end is provided
-  }
-
+  const params = getUrlSearchParams({ event, limit, beginSearchPeriod, endSearchPeriod });
   const url = `https://api.mailgun.net/v3/${credentials.domain}/events?${params.toString()}`;
 
   const response = await fetch(url, {
@@ -118,43 +120,8 @@ export const listEmailEventsHandler = async ({
     ).promptResponse;
   }
 
-  const grouped: Map<
-    string,
-    { recipient?: string; subject?: string; from?: string; events: { event: string; timestamp: string }[] }
-  > = new Map();
-
   const events = responseData.items || [];
-  for (const e of events) {
-    const messageId = e.message?.headers['message-id'] || '(no message-id)';
-    const isAccepted = e.event === 'accepted';
-    const subject = isAccepted && e.message?.headers.subject ? e.message.headers.subject : undefined;
-    const from = isAccepted && e.message?.headers.from ? e.message.headers.from : undefined;
-    const recipient = isAccepted && e.recipient ? e.recipient : undefined;
-
-    if (!grouped.has(messageId)) {
-      grouped.set(messageId, {
-        recipient,
-        subject,
-        from,
-        events: [],
-      });
-    }
-    const group = grouped.get(messageId)!;
-    if (subject && !group.subject) {
-      group.subject = subject;
-    }
-    if (from && !group.from) {
-      group.from = from;
-    }
-    if (recipient && !group.recipient) {
-      group.recipient = recipient;
-    }
-
-    group.events.push({
-      event: e.event || '',
-      timestamp: e.timestamp ? new Date(e.timestamp * 1000).toISOString() : '',
-    });
-  }
+  const grouped = groupEventsByMessageId(events);
 
   const groupedArray = Array.from(grouped.entries()).map(([messageId, data]) => ({
     message_id: messageId,
@@ -172,19 +139,51 @@ export const listEmailEventsHandler = async ({
   ).promptResponse;
 };
 
-interface MailgunEventsResponse {
-  items: MailgunEvent[];
-}
+const getUrlSearchParams = ({ event, limit, beginSearchPeriod, endSearchPeriod }: ListEmailEvents): URLSearchParams => {
+  const searchParams = new URLSearchParams();
+  if (event) {
+    searchParams.append('event', event);
+  }
+  if (limit) {
+    searchParams.append('limit', limit.toString());
+  }
+  if (beginSearchPeriod) {
+    searchParams.append('begin', (new Date(beginSearchPeriod).getTime() / 1000).toString());
+  }
+  if (endSearchPeriod) {
+    searchParams.append('end', (new Date(endSearchPeriod).getTime() / 1000).toString());
+  }
+  if (beginSearchPeriod && !endSearchPeriod) {
+    searchParams.append('end', (Date.now() / 1000).toString()); // Default to now if no end is provided
+  }
+  return searchParams;
+};
 
-interface MailgunEvent {
-  timestamp?: number;
-  event?: EventType;
-  recipient?: string;
-  message?: {
-    headers: {
-      'message-id': string;
-      from?: string;
-      subject?: string;
-    };
-  };
-}
+// Only the "accepted" event carries the recipient/subject/from headers; later events
+// for the same message-id (delivered, opened, ...) only add to the events timeline.
+const acceptedFieldsOf = (e: MailgunEvent): MailgunEventFields =>
+  e.event === 'accepted'
+    ? { recipient: e.recipient, subject: e.message?.headers.subject, from: e.message?.headers.from }
+    : {};
+
+const groupEventsByMessageId = (events: MailgunEvent[]): Map<string, EmailEventGroup> => {
+  const grouped = new Map<string, EmailEventGroup>();
+
+  for (const e of events) {
+    const messageId = e.message?.headers['message-id'] || '(no message-id)';
+    const group = grouped.get(messageId) ?? { events: [] };
+    grouped.set(messageId, group);
+
+    const accepted = acceptedFieldsOf(e);
+    group.subject ??= accepted.subject;
+    group.from ??= accepted.from;
+    group.recipient ??= accepted.recipient;
+
+    group.events.push({
+      event: e.event || '',
+      timestamp: e.timestamp ? new Date(e.timestamp * 1000).toISOString() : '',
+    });
+  }
+
+  return grouped;
+};

--- a/src/tools/email/list-email-templates.ts
+++ b/src/tools/email/list-email-templates.ts
@@ -38,7 +38,7 @@ export const registerListEmailTemplates = (server: McpServer, tags: Tags[]) => {
 };
 
 export const listEmailTemplatesHandler = async ({ domain }: ListEmailTemplates): Promise<IPromptResponse> => {
-  const maybeCredentials = await getMailgunCredentials(domain);
+  const maybeCredentials = getMailgunCredentials(domain);
   if (isPromptResponse(maybeCredentials)) {
     return maybeCredentials.promptResponse;
   }

--- a/src/tools/email/retrieve-email-info.ts
+++ b/src/tools/email/retrieve-email-info.ts
@@ -101,7 +101,16 @@ export const retrieveEmailInfoHandler = async ({ emailId, domain }: RetrieveEmai
     events: events,
   };
 
-  const storedEmail = await fetch(storageUrl!, {
+  if (!storageUrl) {
+    return new PromptResponse(
+      JSON.stringify({
+        success: false,
+        error: `No stored email content found for email ID ${emailId} (no "accepted" event was recorded).`,
+      }),
+    ).promptResponse;
+  }
+
+  const storedEmail = await fetch(storageUrl, {
     method: 'GET',
     headers: {
       Authorization: 'Basic ' + Buffer.from(`api:${credentials.apiKey}`).toString('base64'),

--- a/src/tools/email/utils/mailgun-tools-helper.ts
+++ b/src/tools/email/utils/mailgun-tools-helper.ts
@@ -1,5 +1,5 @@
 import { ToolsConfig } from '../../../types';
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 export const toolsConfig: Record<string, ToolsConfig> = {
   analyticsMetrics: {

--- a/src/tools/voice/conference.ts
+++ b/src/tools/voice/conference.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerTracedTool } from '../../telemetry/register-traced-tool';
 import { Voice } from '@sinch/voice';

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -1,4 +1,4 @@
-import process from 'process';
+import process from 'node:process';
 import pkg from '../package.json';
 const mcpServerVersion = pkg.version;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,9 +11,9 @@ export const matchesAnyTag = (tags: string[], filteringTags: string[]): boolean 
   }
 
   const normalizedTags = tags.map((tag) => tag.toLowerCase());
-  const normalizedFilteringTags = filteringTags.map((tag) => tag.toLowerCase());
+  const normalizedFilteringTags = new Set(filteringTags.map((tag) => tag.toLowerCase()));
 
-  return normalizedTags.some((tag) => normalizedFilteringTags.includes(tag));
+  return normalizedTags.some((tag) => normalizedFilteringTags.has(tag));
 };
 
 export const formatUserAgent = (toolName: string, userId: string): string => {


### PR DESCRIPTION
- Fix `toChannelCredentialRequest`'s cognitive complexity (22→~3) by replacing 11 near-identical if-branches with a single passthrough loop over credential field names
- Fix `listEmailEventsHandler`'s cognitive complexity (34→~5) by extracting `getUrlSearchParams` and `groupEventsByMessageId` out of the handler
- Fix a real bug in `retrieveEmailInfoHandler` where `fetch` could be called with an `undefined` URL when an email has no "accepted" event; return a clean error response instead
- Use the `node:` prefix for builtin imports (`crypto`, `http`, `async_hooks`, `process`) across 7 files
- Merge the duplicate `@sinch/conversation` import in `app-tools-helper.ts`
- Simplify `formatListAllAppsResponse`'s null check to an optional chain
- Remove a stray `await` on `getMailgunCredentials` (a synchronous function) in `list-email-templates.ts`
- Extract the nested ternary in `extractBearerToken` into an if/else
- Use a `Set` instead of array `.includes()` for tag filtering in `matchesAnyTag`
- Leave the remaining SonarQube findings as won't-fix: negated ternaries (no readability gain), top-level-await suggestions (incompatible with the CJS build), redundant string-literal unions (intentional autocomplete-with-escape-hatch pattern), and the `send-message-builder.ts` loop-variable reassignment (removing it breaks the MMS→SMS fallback)