### PR TITLE
feat: resolve agent M2M credentials from AGENT_CREDENTIALS map via x-agent-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,8 +429,8 @@ The server resolves the `x-agent-id` header against the `AGENT_CREDENTIALS` envi
 
 Resolution order per request:
 
-1. If `x-agent-id` is present and found in `AGENT_CREDENTIALS`, the mapped credentials are used (they take precedence over `X-Sinch-Credentials`).
-2. If `x-agent-id` is present but **unknown**, a warning is logged and the server falls back to `X-Sinch-Credentials` if provided; otherwise the tool call returns an explanatory error.
+1. If `x-agent-id` is present and found in `AGENT_CREDENTIALS`, the mapped credentials are used (`X-Sinch-Credentials` is ignored).
+2. If `x-agent-id` is present but **unknown**, the tool call **fails immediately** with an explanatory error (and a warning is logged) — there is no fallback, so configuration mistakes surface right away.
 3. If no `x-agent-id` is sent, `X-Sinch-Credentials` is used as before.
 
 A malformed `AGENT_CREDENTIALS` value (invalid JSON or missing fields) makes the server **refuse to start** in multi-tenant mode. Mapped credentials share the same OAuth token LRU cache as header-provided ones.

--- a/README.md
+++ b/README.md
@@ -413,6 +413,18 @@ Agent integrations (e.g. an agent installed in a Gemini Enterprise app) may send
 | ------------ | -------------------------------------------------- |
 | `x-agent-id` | Agent installation identifier (e.g. GE `OrderId`) |
 
+#### `Authorization` user JWT (optional)
+
+After the end-user completes the OAuth login and consent flow, agent integrations may send the resulting Auth0 user JWT on each request:
+
+| Header          | Value               |
+| --------------- | ------------------- |
+| `Authorization` | `Bearer <user JWT>` |
+
+The server base64-decodes the JWT payload and captures the Sinch claims (`https://sinch.com/project_id`, `https://sinch.com/account_id`, `https://sinch.com/email`, `https://sinch.com/global_user_id`, and `sub`) in the request context, logging them for **audit purposes only**. The token signature is **not** verified and the claims are never used to resolve API credentials (the `x-agent-id` header serves that purpose). A missing or malformed token is ignored and the request proceeds normally. In the long term, the user JWT will be exchanged for an M2M JWT, replacing the custom headers.
+
+Note: in **single-tenant** mode the `Authorization` header carries the MCP API key instead; an opaque key is not a JWT, so no claims are captured.
+
 #### MCP_API_KEYS key rotation
 
 Use `MCP_API_KEYS` (comma-separated) in **single-tenant** mode to accept an old and new gateway key during rotation, then remove the retired key.

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Here is the list of tools available in the MCP server (all the phone numbers mus
 
 ### WhatsApp Template Tools
 
-| Tool                                        | Description                                                                                                                                                                                                                                                                                 | Tags                    |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| **list-whatsapp-templates**                 | List the WhatsApp channel-specific message templates (managed by Meta). Omni-channel templates can be fetched with the `list-messaging-templates` tool. <br> _Example prompt_: "Show me my WhatsApp templates."                                                                             |
-| **create-whatsapp-template**                | Create a WhatsApp message template, as a draft or submitted for review. <br> _Example prompt_: "Create a WhatsApp UTILITY template named order_confirmation in English with body text 'Your order {{1}} has shipped.'"                                                                      | whatsapp, configuration |
-| **update-whatsapp-template**                | Update a WhatsApp message template draft (or reset an APPROVED/REJECTED/PAUSED/DISABLED template to draft) by name and language. <br> _Example prompt_: "Update the order_confirmation EN WhatsApp template's body text to 'Your order {{1}} has shipped today.' and submit it for review." | whatsapp, configuration |
+| Tool                                         | Description                                                                                                                                                                                                                                                                                 | Tags                    |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| **list-whatsapp-templates**                  | List the WhatsApp channel-specific message templates (managed by Meta). Omni-channel templates can be fetched with the `list-messaging-templates` tool. <br> _Example prompt_: "Show me my WhatsApp templates."                                                                             |
+| **create-whatsapp-template**                 | Create a WhatsApp message template, as a draft or submitted for review. <br> _Example prompt_: "Create a WhatsApp UTILITY template named order_confirmation in English with body text 'Your order {{1}} has shipped.'"                                                                      | whatsapp, configuration |
+| **update-whatsapp-template**                 | Update a WhatsApp message template draft (or reset an APPROVED/REJECTED/PAUSED/DISABLED template to draft) by name and language. <br> _Example prompt_: "Update the order_confirmation EN WhatsApp template's body text to 'Your order {{1}} has shipped today.' and submit it for review." | whatsapp, configuration |
 | **delete-single-whatsapp-template-language** | Delete a single language variant of a WhatsApp message template by name and language — other languages of the same template name are unaffected. <br> _Example prompt_: "Delete the draft of the order_confirmation EN WhatsApp template."                                                  | whatsapp, configuration |
 | **delete-all-whatsapp-template-languages**   | Delete every language variant of a WhatsApp message template by name in one call. <br> _Example prompt_: "Delete all language variants of the order_confirmation WhatsApp template."                                                                                                        | whatsapp, configuration |
 
@@ -407,11 +407,33 @@ curl -X POST "http://localhost:8000/mcp" \
 
 #### `x-agent-id` header (multi-tenant only)
 
-Agent integrations (e.g. an agent installed in a Gemini Enterprise app) may send an `x-agent-id` header carrying the unique installation identifier (the Marketplace **OrderId**). Its purpose is to distinguish which installation is calling the MCP server, so it is meant for **multi-tenant** deployments only: it will be used to resolve the caller's Sinch credentials in an upcoming release. In single-tenant mode credentials always come from the server environment, so the header serves no purpose there. This custom header is a temporary mechanism until a token-exchange capability is available over M2M authentication.
+Agent integrations (e.g. an agent installed in a Gemini Enterprise app) may send an `x-agent-id` header carrying the unique installation identifier (the Marketplace **OrderId**). It is used to resolve the caller's Sinch M2M credentials from the server-side `AGENT_CREDENTIALS` map (see below), so it is meant for **multi-tenant** deployments only. In single-tenant mode credentials always come from the server environment, so the header serves no purpose there. This custom header is a temporary mechanism until a token-exchange capability is available over M2M authentication.
 
-| Header       | Value                                              |
-| ------------ | -------------------------------------------------- |
+| Header       | Value                                             |
+| ------------ | ------------------------------------------------- |
 | `x-agent-id` | Agent installation identifier (e.g. GE `OrderId`) |
+
+#### `AGENT_CREDENTIALS` map (multi-tenant only)
+
+The server resolves the `x-agent-id` header against the `AGENT_CREDENTIALS` environment variable, a JSON map of known agent installations to their Sinch M2M credentials:
+
+```json
+{
+  "<agentId>": {
+    "projectId": "<Sinch project id>",
+    "accessKeyId": "<Sinch access key id>",
+    "accessKeySecret": "<Sinch access key secret>"
+  }
+}
+```
+
+Resolution order per request:
+
+1. If `x-agent-id` is present and found in `AGENT_CREDENTIALS`, the mapped credentials are used (they take precedence over `X-Sinch-Credentials`).
+2. If `x-agent-id` is present but **unknown**, a warning is logged and the server falls back to `X-Sinch-Credentials` if provided; otherwise the tool call returns an explanatory error.
+3. If no `x-agent-id` is sent, `X-Sinch-Credentials` is used as before.
+
+A malformed `AGENT_CREDENTIALS` value (invalid JSON or missing fields) makes the server **refuse to start** in multi-tenant mode. Mapped credentials share the same OAuth token LRU cache as header-provided ones.
 
 #### `Authorization` user JWT (optional)
 

--- a/src/__mocks__/env.ts
+++ b/src/__mocks__/env.ts
@@ -17,6 +17,7 @@ export type MockServerEnv = {
   OTEL_PROPAGATORS?: string;
   LOG_LEVEL?: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent';
   MCP_TAGS?: string;
+  AGENT_CREDENTIALS?: string;
 };
 
 export const mockEnv: MockServerEnv = {};

--- a/src/auth/agent-credentials.ts
+++ b/src/auth/agent-credentials.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod';
+import { env } from '../env';
+import { buildCredentialCacheKey, type SinchOAuthCredentials } from './sinch-oauth-credentials';
+
+/**
+ * The AGENT_CREDENTIALS environment variable holds the map of known agent
+ * installations (keyed by the identifier sent in the x-agent-id header, e.g.
+ * the Gemini Enterprise Marketplace OrderId) to their Sinch M2M credentials:
+ *
+ *   {
+ *     "<agentId>": {
+ *       "projectId": "...",
+ *       "accessKeyId": "...",
+ *       "accessKeySecret": "..."
+ *     }
+ *   }
+ *
+ * Temporary mechanism until a token-exchange capability is available over M2M
+ * authentication, at which point the user JWT will be exchanged for an M2M
+ * JWT and this map will go away.
+ */
+export const AGENT_CREDENTIALS_ENV_VAR = 'AGENT_CREDENTIALS';
+
+const agentCredentialsEntrySchema = z.object({
+  projectId: z.string().trim().min(1),
+  accessKeyId: z.string().trim().min(1),
+  accessKeySecret: z.string().trim().min(1),
+});
+
+const agentCredentialsMapSchema = z.record(z.string().min(1), agentCredentialsEntrySchema);
+
+type AgentCredentialsMap = ReadonlyMap<string, SinchOAuthCredentials>;
+
+const EMPTY_MAP: AgentCredentialsMap = new Map();
+
+let cachedCredentialsByAgentId: AgentCredentialsMap | undefined;
+
+const parseAgentCredentials = (rawValue: string): AgentCredentialsMap => {
+  let json: unknown;
+  try {
+    json = JSON.parse(rawValue);
+  } catch {
+    throw new Error(
+      `${AGENT_CREDENTIALS_ENV_VAR} is not valid JSON. ` +
+        'Expected a map of agent ids to { projectId, accessKeyId, accessKeySecret } objects.',
+    );
+  }
+
+  const parsed = agentCredentialsMapSchema.safeParse(json);
+  if (!parsed.success) {
+    // Report offending agent ids and fields only; never echo credential values.
+    const issues = parsed.error.issues.map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`);
+    throw new Error(`${AGENT_CREDENTIALS_ENV_VAR} has an invalid shape: ${issues.join('; ')}`);
+  }
+
+  return new Map(
+    Object.entries(parsed.data).map(([agentId, entry]) => [
+      agentId,
+      {
+        projectId: entry.projectId,
+        keyId: entry.accessKeyId,
+        keySecret: entry.accessKeySecret,
+        cacheKey: buildCredentialCacheKey(entry.projectId, entry.accessKeyId, entry.accessKeySecret),
+      },
+    ]),
+  );
+};
+
+/**
+ * Parses AGENT_CREDENTIALS once and caches the result for O(1) per-request
+ * lookups. Throws on a malformed value: call it at server startup so a bad
+ * configuration refuses to start instead of failing on the first request.
+ */
+export const loadAgentCredentials = (): AgentCredentialsMap => {
+  if (!cachedCredentialsByAgentId) {
+    const rawValue = env.AGENT_CREDENTIALS?.trim();
+    cachedCredentialsByAgentId = rawValue ? parseAgentCredentials(rawValue) : EMPTY_MAP;
+  }
+  return cachedCredentialsByAgentId;
+};
+
+export const resolveAgentCredentials = (agentId: string): SinchOAuthCredentials | undefined => {
+  return loadAgentCredentials().get(agentId);
+};
+
+export const clearAgentCredentialsCacheForTests = (): void => {
+  cachedCredentialsByAgentId = undefined;
+};

--- a/src/auth/agent-credentials.ts
+++ b/src/auth/agent-credentials.ts
@@ -27,13 +27,25 @@ const agentCredentialsEntrySchema = z.object({
   accessKeySecret: z.string().trim().min(1),
 });
 
-const agentCredentialsMapSchema = z.record(z.string().min(1), agentCredentialsEntrySchema);
+const agentCredentialsMapSchema = z.record(z.string().trim().min(1), agentCredentialsEntrySchema);
 
 type AgentCredentialsMap = ReadonlyMap<string, SinchOAuthCredentials>;
 
 const EMPTY_MAP: AgentCredentialsMap = new Map();
 
 let cachedCredentialsByAgentId: AgentCredentialsMap | undefined;
+
+const findDuplicateTrimmedKey = (keys: string[]): string | undefined => {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    const trimmed = key.trim();
+    if (seen.has(trimmed)) {
+      return trimmed;
+    }
+    seen.add(trimmed);
+  }
+  return undefined;
+};
 
 const parseAgentCredentials = (rawValue: string): AgentCredentialsMap => {
   let json: unknown;
@@ -51,6 +63,13 @@ const parseAgentCredentials = (rawValue: string): AgentCredentialsMap => {
     // Report offending agent ids and fields only; never echo credential values.
     const issues = parsed.error.issues.map((issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`);
     throw new Error(`${AGENT_CREDENTIALS_ENV_VAR} has an invalid shape: ${issues.join('; ')}`);
+  }
+
+  // Zod already trims the record keys, silently keeping the last entry when two raw
+  // keys collapse to the same trimmed id — detect that on the raw keys instead.
+  const duplicateAgentId = findDuplicateTrimmedKey(Object.keys(json as Record<string, unknown>));
+  if (duplicateAgentId !== undefined) {
+    throw new Error(`${AGENT_CREDENTIALS_ENV_VAR} contains duplicate agent id "${duplicateAgentId}" after trimming.`);
   }
 
   return new Map(

--- a/src/auth/credential-context.ts
+++ b/src/auth/credential-context.ts
@@ -6,6 +6,7 @@ import {
   type SinchOAuthCredentials,
 } from './sinch-oauth-credentials';
 import { extractHeaderValue } from '../utils';
+import { decodeUserJwtHeader, type SinchUserClaims } from './user-jwt';
 
 /**
  * Custom header carrying the agent installation identifier (e.g. the Gemini
@@ -18,6 +19,7 @@ export const AGENT_ID_HEADER = 'x-agent-id';
 type RequestAuthContext = {
   credentials?: SinchOAuthCredentials;
   agentId?: string;
+  userClaims?: SinchUserClaims;
 };
 
 const requestAuthStorage = new AsyncLocalStorage<RequestAuthContext>();
@@ -30,10 +32,15 @@ export const getRequestAgentId = (): string | undefined => {
   return requestAuthStorage.getStore()?.agentId;
 };
 
+export const getRequestUserClaims = (): SinchUserClaims | undefined => {
+  return requestAuthStorage.getStore()?.userClaims;
+};
+
 export const runWithHttpCredentialHeaders = <T>(headers: IncomingHttpHeaders, fn: () => T): T => {
   const context: RequestAuthContext = {
     credentials: parseSinchCredentialsHeader(headers[SINCH_CREDENTIALS_HEADER]),
     agentId: extractHeaderValue(headers[AGENT_ID_HEADER]),
+    userClaims: decodeUserJwtHeader(headers.authorization),
   };
   return requestAuthStorage.run(context, fn);
 };

--- a/src/auth/resolve-sinch-oauth-credentials.ts
+++ b/src/auth/resolve-sinch-oauth-credentials.ts
@@ -1,24 +1,47 @@
-import { getRequestSinchOAuthCredentials } from './credential-context';
+import { resolveAgentCredentials } from './agent-credentials';
+import { AGENT_ID_HEADER, getRequestAgentId, getRequestSinchOAuthCredentials } from './credential-context';
 import { getHttpCredentialSource } from './http-credential-mode';
 import {
   sinchOAuthCredentialsFromEnv,
   SINCH_CREDENTIALS_HEADER,
   type SinchOAuthCredentials,
 } from './sinch-oauth-credentials';
+import { logger } from '../telemetry/logger';
 import { PromptResponse } from '../types';
 
 export const resolveSinchOAuthCredentials = (): SinchOAuthCredentials | PromptResponse => {
-  // Multi-tenant HTTP: credentials come only from X-Sinch-Credentials (no server env).
+  // Multi-tenant HTTP: credentials come from the request, never from the server env.
   if (getHttpCredentialSource() === 'request-header') {
-    const fromRequest = getRequestSinchOAuthCredentials();
-    if (!fromRequest) {
-      return new PromptResponse(`Missing ${SINCH_CREDENTIALS_HEADER} header (Base64 of projectId:keyId:keySecret).`);
+    // The x-agent-id header takes precedence: a known agent installation is
+    // mapped to its M2M credentials through the AGENT_CREDENTIALS env var.
+    const agentId = getRequestAgentId();
+    if (agentId) {
+      const fromAgent = resolveAgentCredentials(agentId);
+      if (fromAgent) {
+        return fromAgent;
+      }
+      logger.warn(
+        { agent_id: agentId },
+        `Unknown agent id in ${AGENT_ID_HEADER} header: not present in the agent credentials map`,
+      );
     }
-    return fromRequest;
+
+    const fromRequest = getRequestSinchOAuthCredentials();
+    if (fromRequest) {
+      return fromRequest;
+    }
+
+    if (agentId) {
+      return new PromptResponse(
+        `Unknown agent id "${agentId}": it is not present in the server's agent credentials map, ` +
+          `and no ${SINCH_CREDENTIALS_HEADER} header was provided as a fallback.`,
+      );
+    }
+    return new PromptResponse(`Missing ${SINCH_CREDENTIALS_HEADER} header (Base64 of projectId:keyId:keySecret).`);
   }
 
   // Single-tenant HTTP and stdio: credentials come only from server env.
-  // X-Sinch-Credentials is ignored when MCP_API_KEY is configured (no override).
+  // Request headers are ignored when MCP_API_KEY is configured (no override).
   const fromEnv = sinchOAuthCredentialsFromEnv();
   if (fromEnv) {
     return fromEnv;

--- a/src/auth/resolve-sinch-oauth-credentials.ts
+++ b/src/auth/resolve-sinch-oauth-credentials.ts
@@ -12,8 +12,9 @@ import { PromptResponse } from '../types';
 export const resolveSinchOAuthCredentials = (): SinchOAuthCredentials | PromptResponse => {
   // Multi-tenant HTTP: credentials come from the request, never from the server env.
   if (getHttpCredentialSource() === 'request-header') {
-    // The x-agent-id header takes precedence: a known agent installation is
-    // mapped to its M2M credentials through the AGENT_CREDENTIALS env var.
+    // When x-agent-id is sent, it is the only credential mechanism considered: an
+    // unknown agent id fails immediately (fail-closed) rather than silently falling
+    // back to X-Sinch-Credentials, so configuration mistakes surface right away.
     const agentId = getRequestAgentId();
     if (agentId) {
       const fromAgent = resolveAgentCredentials(agentId);
@@ -24,6 +25,9 @@ export const resolveSinchOAuthCredentials = (): SinchOAuthCredentials | PromptRe
         { agent_id: agentId },
         `Unknown agent id in ${AGENT_ID_HEADER} header: not present in the agent credentials map`,
       );
+      return new PromptResponse(
+        `Unknown agent id "${agentId}": it is not present in the server's agent credentials map.`,
+      );
     }
 
     const fromRequest = getRequestSinchOAuthCredentials();
@@ -31,12 +35,6 @@ export const resolveSinchOAuthCredentials = (): SinchOAuthCredentials | PromptRe
       return fromRequest;
     }
 
-    if (agentId) {
-      return new PromptResponse(
-        `Unknown agent id "${agentId}": it is not present in the server's agent credentials map, ` +
-          `and no ${SINCH_CREDENTIALS_HEADER} header was provided as a fallback.`,
-      );
-    }
     return new PromptResponse(`Missing ${SINCH_CREDENTIALS_HEADER} header (Base64 of projectId:keyId:keySecret).`);
   }
 

--- a/src/auth/user-jwt.ts
+++ b/src/auth/user-jwt.ts
@@ -1,0 +1,78 @@
+import { extractBearerToken } from './mcp-api-key';
+
+/**
+ * Sinch-namespaced claims carried by the Auth0 user JWT that agent
+ * integrations (e.g. an agent installed in a Gemini Enterprise app) send in
+ * the Authorization header after the end-user OAuth flow.
+ */
+export const SINCH_PROJECT_ID_CLAIM = 'https://sinch.com/project_id';
+export const SINCH_ACCOUNT_ID_CLAIM = 'https://sinch.com/account_id';
+export const SINCH_EMAIL_CLAIM = 'https://sinch.com/email';
+export const SINCH_GLOBAL_USER_ID_CLAIM = 'https://sinch.com/global_user_id';
+
+export type SinchUserClaims = {
+  projectId?: string;
+  accountId?: string;
+  email?: string;
+  globalUserId?: string;
+  subject?: string;
+};
+
+const decodeJwtPayload = (token: string): Record<string, unknown> | undefined => {
+  const segments = token.split('.');
+  if (segments.length !== 3) {
+    return undefined;
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(Buffer.from(segments[1], 'base64url').toString('utf8'));
+  } catch {
+    return undefined;
+  }
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return undefined;
+  }
+
+  return payload as Record<string, unknown>;
+};
+
+const stringClaim = (payload: Record<string, unknown>, claim: string): string | undefined => {
+  const value = payload[claim];
+  return typeof value === 'string' && value.trim() ? value : undefined;
+};
+
+/**
+ * Extracts the Sinch user claims from a `Bearer <JWT>` Authorization header.
+ *
+ * The payload is base64url-decoded WITHOUT verifying the token signature,
+ * issuer, or expiry: the claims are self-reported and used for audit purposes
+ * only (credentials are resolved through other mechanisms). Verification will
+ * come with the future user-JWT to M2M-JWT token exchange.
+ *
+ * Returns undefined for anything that is not a well-formed three-segment JWT
+ * with a JSON object payload (e.g. an opaque MCP API key in single-tenant
+ * mode, or a missing header).
+ */
+export const decodeUserJwtHeader = (
+  authorizationHeader: string | string[] | undefined,
+): SinchUserClaims | undefined => {
+  const token = extractBearerToken(authorizationHeader);
+  if (!token) {
+    return undefined;
+  }
+
+  const payload = decodeJwtPayload(token);
+  if (!payload) {
+    return undefined;
+  }
+
+  return {
+    projectId: stringClaim(payload, SINCH_PROJECT_ID_CLAIM),
+    accountId: stringClaim(payload, SINCH_ACCOUNT_ID_CLAIM),
+    email: stringClaim(payload, SINCH_EMAIL_CLAIM) ?? stringClaim(payload, 'email'),
+    globalUserId: stringClaim(payload, SINCH_GLOBAL_USER_ID_CLAIM),
+    subject: stringClaim(payload, 'sub'),
+  };
+};

--- a/src/env.ts
+++ b/src/env.ts
@@ -24,6 +24,7 @@ export const env = createEnv({
     OTEL_PROPAGATORS: z.string().optional(),
     LOG_LEVEL: z.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']).optional(),
     MCP_TAGS: z.string().optional(),
+    AGENT_CREDENTIALS: z.string().optional(),
   },
   runtimeEnvStrict: {
     PROJECT_ID: process.env.PROJECT_ID,
@@ -44,6 +45,7 @@ export const env = createEnv({
     OTEL_PROPAGATORS: process.env.OTEL_PROPAGATORS,
     LOG_LEVEL: process.env.LOG_LEVEL,
     MCP_TAGS: process.env.MCP_TAGS,
+    AGENT_CREDENTIALS: process.env.AGENT_CREDENTIALS,
   },
   emptyStringAsUndefined: true,
   onValidationError: (issues: readonly StandardSchemaV1.Issue[]) => {

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,13 +3,14 @@ import express, { type Request, type Response } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import dotenv from 'dotenv';
-import { runWithHttpCredentialHeaders } from './auth/credential-context';
+import { getRequestAgentId, getRequestUserClaims, runWithHttpCredentialHeaders } from './auth/credential-context';
 import { setHttpCredentialSource } from './auth/http-credential-mode';
 import { createMcpApiKeyMiddleware, loadMcpApiKeys } from './auth/mcp-api-key';
 import { getMaxMcpSessions, isMcpSessionCapacityReached } from './auth/http-session-limits';
 import { env } from './env';
 import { buildJsonRpcErrorResponse } from './json-rpc';
 import { instantiateMcpServer, getToolsFilter, registerCapabilities } from './server';
+import { logger } from './telemetry/logger';
 
 dotenv.config();
 
@@ -78,6 +79,25 @@ const removeSession = async (sessionId: string): Promise<void> => {
   }
 };
 
+const logUserJwtAuditTrail = (): void => {
+  const claims = getRequestUserClaims();
+  if (!claims) {
+    return;
+  }
+
+  logger.info(
+    {
+      project_id: claims.projectId,
+      account_id: claims.accountId,
+      email: claims.email,
+      global_user_id: claims.globalUserId,
+      sub: claims.subject,
+      agent_id: getRequestAgentId(),
+    },
+    'Agent user request (unverified JWT claims)',
+  );
+};
+
 const createSession = async (): Promise<SessionEntry> => {
   const mcpServer = instantiateMcpServer();
   registerCapabilities(mcpServer, getToolsFilter(process.argv));
@@ -136,7 +156,10 @@ export const createHttpApp = () => {
         return;
       }
 
-      await runWithHttpCredentialHeaders(req.headers, () => entry.transport.handleRequest(req, res, req.body));
+      await runWithHttpCredentialHeaders(req.headers, () => {
+        logUserJwtAuditTrail();
+        return entry.transport.handleRequest(req, res, req.body);
+      });
       return;
     }
 
@@ -155,7 +178,10 @@ export const createHttpApp = () => {
     }
 
     const entry = await createSession();
-    await runWithHttpCredentialHeaders(req.headers, () => entry.transport.handleRequest(req, res, req.body));
+    await runWithHttpCredentialHeaders(req.headers, () => {
+      logUserJwtAuditTrail();
+      return entry.transport.handleRequest(req, res, req.body);
+    });
   };
 
   const app = express();

--- a/src/http.ts
+++ b/src/http.ts
@@ -3,8 +3,9 @@ import express, { type Request, type Response } from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import dotenv from 'dotenv';
+import { loadAgentCredentials, resolveAgentCredentials } from './auth/agent-credentials';
 import { getRequestAgentId, getRequestUserClaims, runWithHttpCredentialHeaders } from './auth/credential-context';
-import { setHttpCredentialSource } from './auth/http-credential-mode';
+import { getHttpCredentialSource, setHttpCredentialSource } from './auth/http-credential-mode';
 import { createMcpApiKeyMiddleware, loadMcpApiKeys } from './auth/mcp-api-key';
 import { getMaxMcpSessions, isMcpSessionCapacityReached } from './auth/http-session-limits';
 import { env } from './env';
@@ -81,18 +82,26 @@ const removeSession = async (sessionId: string): Promise<void> => {
 
 const logUserJwtAuditTrail = (): void => {
   const claims = getRequestUserClaims();
-  if (!claims) {
+  const agentId = getRequestAgentId();
+  if (!claims && !agentId) {
     return;
   }
 
   logger.info(
     {
-      project_id: claims.projectId,
-      account_id: claims.accountId,
-      email: claims.email,
-      global_user_id: claims.globalUserId,
-      sub: claims.subject,
-      agent_id: getRequestAgentId(),
+      project_id: claims?.projectId,
+      account_id: claims?.accountId,
+      email: claims?.email,
+      global_user_id: claims?.globalUserId,
+      sub: claims?.subject,
+      agent_id: agentId,
+      // Tenant the request will act as, resolved from the AGENT_CREDENTIALS map (never secrets).
+      // Only meaningful in multi-tenant mode; in single-tenant mode the map is not validated at
+      // startup, so it must not be parsed here either.
+      tenant_project_id:
+        agentId && getHttpCredentialSource() === 'request-header'
+          ? resolveAgentCredentials(agentId)?.projectId
+          : undefined,
     },
     'Agent user request (unverified JWT claims)',
   );
@@ -143,6 +152,8 @@ export const createHttpApp = () => {
           'Either set CONVERSATION_REGION, or set MCP_API_KEY to run in single-tenant mode.',
       );
     }
+    // Fail fast on a malformed AGENT_CREDENTIALS map rather than on the first request.
+    loadAgentCredentials();
     setHttpCredentialSource('request-header');
   }
 

--- a/tests/auth/agent-credentials.test.ts
+++ b/tests/auth/agent-credentials.test.ts
@@ -1,0 +1,129 @@
+import {
+  clearAgentCredentialsCacheForTests,
+  loadAgentCredentials,
+  resolveAgentCredentials,
+} from '../../src/auth/agent-credentials';
+import { buildCredentialCacheKey } from '../../src/auth/sinch-oauth-credentials';
+import { mockEnv, resetMockEnv } from '../helpers/mock-env';
+
+const validMap = {
+  'order-42': {
+    projectId: 'project-a',
+    accessKeyId: 'key-a',
+    accessKeySecret: 'secret-a',
+  },
+  'order-43': {
+    projectId: 'project-b',
+    accessKeyId: 'key-b',
+    accessKeySecret: 'secret-b',
+  },
+};
+
+describe('agent-credentials', () => {
+  beforeEach(() => {
+    resetMockEnv();
+    clearAgentCredentialsCacheForTests();
+  });
+
+  describe('loadAgentCredentials', () => {
+    it('returns an empty map when AGENT_CREDENTIALS is not set', () => {
+      expect(loadAgentCredentials().size).toBe(0);
+    });
+
+    it('returns an empty map when AGENT_CREDENTIALS is blank', () => {
+      mockEnv.AGENT_CREDENTIALS = '   ';
+      expect(loadAgentCredentials().size).toBe(0);
+    });
+
+    it('parses a valid map into SinchOAuthCredentials entries', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify(validMap);
+
+      const credentials = loadAgentCredentials();
+
+      expect(credentials.size).toBe(2);
+      expect(credentials.get('order-42')).toEqual({
+        projectId: 'project-a',
+        keyId: 'key-a',
+        keySecret: 'secret-a',
+        cacheKey: buildCredentialCacheKey('project-a', 'key-a', 'secret-a'),
+      });
+    });
+
+    it('caches the parsed map across calls', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify(validMap);
+      const first = loadAgentCredentials();
+
+      // A later env change is not picked up until the cache is cleared.
+      mockEnv.AGENT_CREDENTIALS = '{}';
+      expect(loadAgentCredentials()).toBe(first);
+
+      clearAgentCredentialsCacheForTests();
+      expect(loadAgentCredentials().size).toBe(0);
+    });
+
+    it('throws on invalid JSON without echoing the value', () => {
+      mockEnv.AGENT_CREDENTIALS = '{secret-blob';
+
+      let error: Error | undefined;
+      try {
+        loadAgentCredentials();
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).toMatch(/AGENT_CREDENTIALS is not valid JSON/);
+      expect(error?.message).not.toContain('secret-blob');
+    });
+
+    it('throws when an entry is missing a field', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify({
+        'order-42': { projectId: 'project-a', accessKeyId: 'key-a' },
+      });
+      expect(() => loadAgentCredentials()).toThrow(/invalid shape.*order-42\.accessKeySecret/);
+    });
+
+    it('throws when a field is empty', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify({
+        'order-42': { projectId: '', accessKeyId: 'key-a', accessKeySecret: 'secret-a' },
+      });
+      expect(() => loadAgentCredentials()).toThrow(/invalid shape.*order-42\.projectId/);
+    });
+
+    it('does not include credential values in shape errors', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify({
+        'order-42': { projectId: 'project-a', accessKeyId: 42, accessKeySecret: 'super-secret-value' },
+      });
+
+      let error: Error | undefined;
+      try {
+        loadAgentCredentials();
+      } catch (caught) {
+        error = caught as Error;
+      }
+
+      expect(error?.message).toMatch(/invalid shape/);
+      expect(error?.message).not.toContain('super-secret-value');
+    });
+
+    it('throws when the value is not an object map', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify(['order-42']);
+      expect(() => loadAgentCredentials()).toThrow(/invalid shape/);
+    });
+  });
+
+  describe('resolveAgentCredentials', () => {
+    it('resolves a known agent id', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify(validMap);
+      expect(resolveAgentCredentials('order-43')?.projectId).toBe('project-b');
+    });
+
+    it('returns undefined for an unknown agent id', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify(validMap);
+      expect(resolveAgentCredentials('order-99')).toBeUndefined();
+    });
+
+    it('returns undefined when no map is configured', () => {
+      expect(resolveAgentCredentials('order-42')).toBeUndefined();
+    });
+  });
+});

--- a/tests/auth/agent-credentials.test.ts
+++ b/tests/auth/agent-credentials.test.ts
@@ -109,6 +109,32 @@ describe('agent-credentials', () => {
       mockEnv.AGENT_CREDENTIALS = JSON.stringify(['order-42']);
       expect(() => loadAgentCredentials()).toThrow(/invalid shape/);
     });
+
+    it('trims whitespace around agent ids', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify({
+        ' order-42 ': { projectId: 'project-a', accessKeyId: 'key-a', accessKeySecret: 'secret-a' },
+      });
+
+      const credentials = loadAgentCredentials();
+
+      expect(credentials.get('order-42')?.projectId).toBe('project-a');
+      expect(credentials.has(' order-42 ')).toBeFalse();
+    });
+
+    it('throws when an agent id is blank', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify({
+        '   ': { projectId: 'project-a', accessKeyId: 'key-a', accessKeySecret: 'secret-a' },
+      });
+      expect(() => loadAgentCredentials()).toThrow(/invalid shape/);
+    });
+
+    it('throws when two agent ids collide after trimming', () => {
+      mockEnv.AGENT_CREDENTIALS = JSON.stringify({
+        'order-42': { projectId: 'project-a', accessKeyId: 'key-a', accessKeySecret: 'secret-a' },
+        ' order-42': { projectId: 'project-b', accessKeyId: 'key-b', accessKeySecret: 'secret-b' },
+      });
+      expect(() => loadAgentCredentials()).toThrow(/duplicate agent id "order-42"/);
+    });
   });
 
   describe('resolveAgentCredentials', () => {

--- a/tests/auth/resolve-sinch-oauth-credentials.test.ts
+++ b/tests/auth/resolve-sinch-oauth-credentials.test.ts
@@ -64,7 +64,7 @@ describe('resolveSinchOAuthCredentials', () => {
       expect(resolved).toMatchObject({ projectId: 'agent-project' });
     });
 
-    it('falls back to x-sinch-credentials for an unknown agent id, with a warning', () => {
+    it('fails closed for an unknown agent id even when x-sinch-credentials is sent', () => {
       mockEnv.AGENT_CREDENTIALS = agentCredentialsMap;
 
       const resolved = runWithHttpCredentialHeaders(
@@ -72,11 +72,11 @@ describe('resolveSinchOAuthCredentials', () => {
         () => resolveSinchOAuthCredentials(),
       );
 
-      expect(resolved).toMatchObject({ projectId: 'header-project' });
+      expect(resolved).toBeInstanceOf(PromptResponse);
       expect(logger.warn).toHaveBeenCalledWith({ agent_id: 'order-99' }, expect.stringContaining('Unknown agent id'));
     });
 
-    it('returns a prompt response for an unknown agent id without a fallback header', () => {
+    it('returns a prompt response naming the unknown agent id', () => {
       mockEnv.AGENT_CREDENTIALS = agentCredentialsMap;
 
       const resolved = runWithHttpCredentialHeaders({ [AGENT_ID_HEADER]: 'order-99' }, () =>

--- a/tests/auth/resolve-sinch-oauth-credentials.test.ts
+++ b/tests/auth/resolve-sinch-oauth-credentials.test.ts
@@ -1,0 +1,144 @@
+import { clearAgentCredentialsCacheForTests } from '../../src/auth/agent-credentials';
+import { AGENT_ID_HEADER, runWithHttpCredentialHeaders } from '../../src/auth/credential-context';
+import { clearHttpCredentialSourceForTests, setHttpCredentialSource } from '../../src/auth/http-credential-mode';
+import { resolveSinchOAuthCredentials } from '../../src/auth/resolve-sinch-oauth-credentials';
+import { logger } from '../../src/telemetry/logger';
+import { PromptResponse } from '../../src/types';
+import { mockEnv, resetMockEnv } from '../helpers/mock-env';
+
+jest.mock('../../src/telemetry/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const CREDENTIALS_HEADER = 'x-sinch-credentials';
+const encodedHeaderCredentials = Buffer.from('header-project:header-key:header-secret').toString('base64');
+
+const agentCredentialsMap = JSON.stringify({
+  'order-42': {
+    projectId: 'agent-project',
+    accessKeyId: 'agent-key',
+    accessKeySecret: 'agent-secret',
+  },
+});
+
+describe('resolveSinchOAuthCredentials', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockEnv();
+    clearAgentCredentialsCacheForTests();
+    clearHttpCredentialSourceForTests();
+  });
+
+  describe('multi-tenant mode (request-header source)', () => {
+    beforeEach(() => {
+      setHttpCredentialSource('request-header');
+    });
+
+    it('resolves a known agent id through the AGENT_CREDENTIALS map', () => {
+      mockEnv.AGENT_CREDENTIALS = agentCredentialsMap;
+
+      const resolved = runWithHttpCredentialHeaders({ [AGENT_ID_HEADER]: 'order-42' }, () =>
+        resolveSinchOAuthCredentials(),
+      );
+
+      expect(resolved).toMatchObject({
+        projectId: 'agent-project',
+        keyId: 'agent-key',
+        keySecret: 'agent-secret',
+      });
+    });
+
+    it('prefers the agent mapping over the x-sinch-credentials header', () => {
+      mockEnv.AGENT_CREDENTIALS = agentCredentialsMap;
+
+      const resolved = runWithHttpCredentialHeaders(
+        { [AGENT_ID_HEADER]: 'order-42', [CREDENTIALS_HEADER]: encodedHeaderCredentials },
+        () => resolveSinchOAuthCredentials(),
+      );
+
+      expect(resolved).toMatchObject({ projectId: 'agent-project' });
+    });
+
+    it('falls back to x-sinch-credentials for an unknown agent id, with a warning', () => {
+      mockEnv.AGENT_CREDENTIALS = agentCredentialsMap;
+
+      const resolved = runWithHttpCredentialHeaders(
+        { [AGENT_ID_HEADER]: 'order-99', [CREDENTIALS_HEADER]: encodedHeaderCredentials },
+        () => resolveSinchOAuthCredentials(),
+      );
+
+      expect(resolved).toMatchObject({ projectId: 'header-project' });
+      expect(logger.warn).toHaveBeenCalledWith({ agent_id: 'order-99' }, expect.stringContaining('Unknown agent id'));
+    });
+
+    it('returns a prompt response for an unknown agent id without a fallback header', () => {
+      mockEnv.AGENT_CREDENTIALS = agentCredentialsMap;
+
+      const resolved = runWithHttpCredentialHeaders({ [AGENT_ID_HEADER]: 'order-99' }, () =>
+        resolveSinchOAuthCredentials(),
+      );
+
+      expect(resolved).toBeInstanceOf(PromptResponse);
+      expect((resolved as PromptResponse).promptResponse.content[0].text).toContain('order-99');
+    });
+
+    it('resolves from x-sinch-credentials when no agent header is sent', () => {
+      const resolved = runWithHttpCredentialHeaders({ [CREDENTIALS_HEADER]: encodedHeaderCredentials }, () =>
+        resolveSinchOAuthCredentials(),
+      );
+
+      expect(resolved).toMatchObject({ projectId: 'header-project' });
+    });
+
+    it('returns a prompt response when neither header is sent', () => {
+      const resolved = runWithHttpCredentialHeaders({}, () => resolveSinchOAuthCredentials());
+
+      expect(resolved).toBeInstanceOf(PromptResponse);
+      expect((resolved as PromptResponse).promptResponse.content[0].text).toContain(CREDENTIALS_HEADER);
+    });
+
+    it('never falls back to server env credentials', () => {
+      mockEnv.PROJECT_ID = 'env-project';
+      mockEnv.KEY_ID = 'env-key';
+      mockEnv.KEY_SECRET = 'env-secret';
+
+      const resolved = runWithHttpCredentialHeaders({}, () => resolveSinchOAuthCredentials());
+
+      expect(resolved).toBeInstanceOf(PromptResponse);
+    });
+  });
+
+  describe('single-tenant and stdio (env source)', () => {
+    it('resolves from the server env', () => {
+      mockEnv.PROJECT_ID = 'env-project';
+      mockEnv.KEY_ID = 'env-key';
+      mockEnv.KEY_SECRET = 'env-secret';
+
+      expect(resolveSinchOAuthCredentials()).toMatchObject({ projectId: 'env-project' });
+    });
+
+    it('ignores the agent header and credentials header', () => {
+      mockEnv.AGENT_CREDENTIALS = agentCredentialsMap;
+      mockEnv.PROJECT_ID = 'env-project';
+      mockEnv.KEY_ID = 'env-key';
+      mockEnv.KEY_SECRET = 'env-secret';
+      setHttpCredentialSource('env');
+
+      const resolved = runWithHttpCredentialHeaders(
+        { [AGENT_ID_HEADER]: 'order-42', [CREDENTIALS_HEADER]: encodedHeaderCredentials },
+        () => resolveSinchOAuthCredentials(),
+      );
+
+      expect(resolved).toMatchObject({ projectId: 'env-project' });
+    });
+
+    it('returns a prompt response when env vars are missing', () => {
+      expect(resolveSinchOAuthCredentials()).toBeInstanceOf(PromptResponse);
+    });
+  });
+});

--- a/tests/auth/user-jwt.test.ts
+++ b/tests/auth/user-jwt.test.ts
@@ -1,0 +1,126 @@
+import {
+  decodeUserJwtHeader,
+  SINCH_ACCOUNT_ID_CLAIM,
+  SINCH_EMAIL_CLAIM,
+  SINCH_GLOBAL_USER_ID_CLAIM,
+  SINCH_PROJECT_ID_CLAIM,
+} from '../../src/auth/user-jwt';
+import { AGENT_ID_HEADER, getRequestUserClaims, runWithHttpCredentialHeaders } from '../../src/auth/credential-context';
+
+const base64Url = (value: object): string => Buffer.from(JSON.stringify(value)).toString('base64url');
+
+const buildJwt = (payload: object): string => {
+  const header = base64Url({ alg: 'RS256', typ: 'JWT' });
+  return `${header}.${base64Url(payload)}.fake-signature`;
+};
+
+const examplePayload = {
+  [SINCH_ACCOUNT_ID_CLAIM]: '244b24e9dd2a45a19547f8c372d6fcab',
+  [SINCH_PROJECT_ID_CLAIM]: 'd1b9c2af-fca6-49a7-8c84-7bdc9c4c50e4',
+  email: 'antoine.sein@mailgun.com',
+  [SINCH_EMAIL_CLAIM]: 'antoine.sein@mailgun.com',
+  [SINCH_GLOBAL_USER_ID_CLAIM]: '81ac881a-5777-4300-aafc-3d3ca6f73115',
+  iss: 'https://id.sinch.com/',
+  sub: 'auth0|664336b8d1aa73fd26ec6068',
+};
+
+describe('user-jwt', () => {
+  describe('decodeUserJwtHeader', () => {
+    it('maps the Sinch claims from a Bearer JWT', () => {
+      const claims = decodeUserJwtHeader(`Bearer ${buildJwt(examplePayload)}`);
+
+      expect(claims).toEqual({
+        projectId: 'd1b9c2af-fca6-49a7-8c84-7bdc9c4c50e4',
+        accountId: '244b24e9dd2a45a19547f8c372d6fcab',
+        email: 'antoine.sein@mailgun.com',
+        globalUserId: '81ac881a-5777-4300-aafc-3d3ca6f73115',
+        subject: 'auth0|664336b8d1aa73fd26ec6068',
+      });
+    });
+
+    it('falls back to the standard email claim when the Sinch one is absent', () => {
+      const claims = decodeUserJwtHeader(`Bearer ${buildJwt({ email: 'user@example.com' })}`);
+      expect(claims?.email).toBe('user@example.com');
+    });
+
+    it('leaves unknown claims undefined', () => {
+      const claims = decodeUserJwtHeader(`Bearer ${buildJwt({ iss: 'https://id.sinch.com/' })}`);
+
+      expect(claims).toEqual({
+        projectId: undefined,
+        accountId: undefined,
+        email: undefined,
+        globalUserId: undefined,
+        subject: undefined,
+      });
+    });
+
+    it('ignores non-string claim values', () => {
+      const claims = decodeUserJwtHeader(`Bearer ${buildJwt({ [SINCH_PROJECT_ID_CLAIM]: 42, sub: null })}`);
+
+      expect(claims?.projectId).toBeUndefined();
+      expect(claims?.subject).toBeUndefined();
+    });
+
+    it('returns undefined for a missing header', () => {
+      expect(decodeUserJwtHeader(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for a non-Bearer scheme', () => {
+      expect(decodeUserJwtHeader(`Basic ${buildJwt(examplePayload)}`)).toBeUndefined();
+    });
+
+    it('returns undefined for an opaque token such as an MCP API key', () => {
+      expect(decodeUserJwtHeader('Bearer my-static-api-key')).toBeUndefined();
+    });
+
+    it('returns undefined when the token does not have three segments', () => {
+      expect(decodeUserJwtHeader('Bearer aaa.bbb')).toBeUndefined();
+      expect(decodeUserJwtHeader('Bearer aaa.bbb.ccc.ddd')).toBeUndefined();
+    });
+
+    it('returns undefined when the payload is not valid JSON', () => {
+      const invalidPayload = Buffer.from('not-json').toString('base64url');
+      expect(decodeUserJwtHeader(`Bearer aaa.${invalidPayload}.ccc`)).toBeUndefined();
+    });
+
+    it('returns undefined when the payload is not a JSON object', () => {
+      const arrayPayload = Buffer.from(JSON.stringify(['a', 'b'])).toString('base64url');
+      expect(decodeUserJwtHeader(`Bearer aaa.${arrayPayload}.ccc`)).toBeUndefined();
+    });
+  });
+
+  describe('request context propagation', () => {
+    it('exposes the user claims within the request scope', () => {
+      const claims = runWithHttpCredentialHeaders({ authorization: `Bearer ${buildJwt(examplePayload)}` }, () =>
+        getRequestUserClaims(),
+      );
+
+      expect(claims?.projectId).toBe('d1b9c2af-fca6-49a7-8c84-7bdc9c4c50e4');
+      expect(claims?.email).toBe('antoine.sein@mailgun.com');
+    });
+
+    it('returns undefined outside a request scope', () => {
+      expect(getRequestUserClaims()).toBeUndefined();
+    });
+
+    it('returns undefined within a request scope when the header is absent', () => {
+      const claims = runWithHttpCredentialHeaders({}, () => getRequestUserClaims());
+      expect(claims).toBeUndefined();
+    });
+
+    it('captures user claims independently from the agent id', () => {
+      const context = runWithHttpCredentialHeaders(
+        {
+          authorization: `Bearer ${buildJwt(examplePayload)}`,
+          [AGENT_ID_HEADER]: 'order-42',
+        },
+        () => getRequestUserClaims(),
+      );
+      expect(context?.globalUserId).toBe('81ac881a-5777-4300-aafc-3d3ca6f73115');
+
+      const withoutJwt = runWithHttpCredentialHeaders({ [AGENT_ID_HEADER]: 'order-42' }, () => getRequestUserClaims());
+      expect(withoutJwt).toBeUndefined();
+    });
+  });
+});

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,4 +1,5 @@
 import { createHttpApp } from '../src/http';
+import { clearAgentCredentialsCacheForTests } from '../src/auth/agent-credentials';
 import { clearHttpCredentialSourceForTests, getHttpCredentialSource } from '../src/auth/http-credential-mode';
 import { mockEnv, resetMockEnv } from './helpers/mock-env';
 
@@ -16,6 +17,7 @@ describe('createHttpApp startup validation', () => {
 
   beforeEach(() => {
     resetMockEnv();
+    clearAgentCredentialsCacheForTests();
     delete process.env.MCP_API_KEY;
     delete process.env.MCP_API_KEYS;
   });
@@ -50,5 +52,26 @@ describe('createHttpApp startup validation', () => {
     process.env.MCP_API_KEY = 'test-api-key';
     expect(() => createHttpApp()).not.toThrow();
     expect(getHttpCredentialSource()).toBe('env');
+  });
+
+  test('throws in multi-tenant mode when AGENT_CREDENTIALS is malformed', () => {
+    mockEnv.CONVERSATION_REGION = 'eu';
+    mockEnv.AGENT_CREDENTIALS = '{not-json';
+    expect(() => createHttpApp()).toThrow(/AGENT_CREDENTIALS is not valid JSON/);
+  });
+
+  test('starts in multi-tenant mode with a valid AGENT_CREDENTIALS map', () => {
+    mockEnv.CONVERSATION_REGION = 'eu';
+    mockEnv.AGENT_CREDENTIALS = JSON.stringify({
+      'order-42': { projectId: 'p', accessKeyId: 'k', accessKeySecret: 's' },
+    });
+    expect(() => createHttpApp()).not.toThrow();
+    expect(getHttpCredentialSource()).toBe('request-header');
+  });
+
+  test('ignores a malformed AGENT_CREDENTIALS in single-tenant mode', () => {
+    process.env.MCP_API_KEY = 'test-api-key';
+    mockEnv.AGENT_CREDENTIALS = '{not-json';
+    expect(() => createHttpApp()).not.toThrow();
   });
 });


### PR DESCRIPTION
In multi-tenant mode, the x-agent-id header is now looked up in the new AGENT_CREDENTIALS env var (JSON map of known agent installations to projectId/accessKeyId/accessKeySecret) so agents no longer need to send Sinch secrets on every request. The map is parsed and validated once at startup (the server refuses to start on a malformed value), mapped credentials reuse the OAuth token LRU cache, and x-sinch-credentials remains as a fallback during the transition. The per-request audit log now also reports the resolved tenant project id.